### PR TITLE
remove unused onboard entries

### DIFF
--- a/BrightID/src/components/OnboardingScreens/Onboard.js
+++ b/BrightID/src/components/OnboardingScreens/Onboard.js
@@ -46,7 +46,7 @@ class Onboard extends React.Component<Props, State> {
     super(props);
     this.state = {
       activeSlide: 0,
-      entries: [...Array(4)],
+      entries: [...Array(2)],
     };
   }
 


### PR DESCRIPTION
Upon installation and startup, the onboard slider only has two pages with content and then has two blank pages. I removed the blank ones.