### PR TITLE
store groups information locally

### DIFF
--- a/BrightID/src/Api/BrightId.js
+++ b/BrightID/src/Api/BrightId.js
@@ -2,23 +2,12 @@
 
 import { create, ApiSauceInstance } from 'apisauce';
 import nacl from 'tweetnacl';
-import CryptoJS from 'crypto-js';
-import {
-  strToUint8Array,
-  uInt8ArrayToB64,
-  b64ToUrlSafeB64,
-} from '../utils/encoding';
+import { strToUint8Array, uInt8ArrayToB64, hash } from '../utils/encoding';
 import store from '../store';
 
 let seedUrl = 'http://node.brightid.org';
 if (__DEV__) {
   seedUrl = 'http://test.brightid.org';
-}
-
-function hash(data) {
-  const h = CryptoJS.SHA256(data);
-  const b = h.toString(CryptoJS.enc.Base64);
-  return b64ToUrlSafeB64(b);
 }
 
 class BrightId {
@@ -117,8 +106,6 @@ class BrightId {
     };
     const res = await this.api.put(`/operations/${op._key}`, op);
     BrightId.throwOnError(res);
-    // we can have group id here if required by sorting and joining
-    // the founders ids and getting sha256 hash from that
   }
 
   async deleteGroup(group: string) {

--- a/BrightID/src/actions/fetchUserInfo.js
+++ b/BrightID/src/actions/fetchUserInfo.js
@@ -11,10 +11,7 @@ import {
 } from './index';
 
 // TODO update connections here
-const fetchUserInfo = () => async (
-  dispatch: dispatch,
-  getState: getState,
-) => {
+const fetchUserInfo = () => async (dispatch: dispatch, getState: getState) => {
   try {
     const {
       eligibleGroups,
@@ -23,11 +20,7 @@ const fetchUserInfo = () => async (
       verifications = [],
       connections = [],
     } = await api.getUserInfo();
-    const oldEligibleGroups = [...getState().eligibleGroups];
-    const remained = oldEligibleGroups.filter( function( el ) {
-      return (! eligibleGroups.some(x => x.id == el.id) && ! currentGroups.some(x => x.id == el.id))
-    });
-    dispatch(setEligibleGroups([...remained, ...eligibleGroups]));
+    dispatch(setEligibleGroups(eligibleGroups));
     dispatch(setCurrentGroups(currentGroups));
     dispatch(setUserScore(__DEV__ ? 100 : score));
     dispatch(setGroupsCount(currentGroups.length));

--- a/BrightID/src/actions/fetchUserInfo.js
+++ b/BrightID/src/actions/fetchUserInfo.js
@@ -11,7 +11,10 @@ import {
 } from './index';
 
 // TODO update connections here
-const fetchUserInfo = () => async (dispatch: dispatch) => {
+const fetchUserInfo = () => async (
+  dispatch: dispatch,
+  getState: getState,
+) => {
   try {
     const {
       eligibleGroups,
@@ -20,7 +23,11 @@ const fetchUserInfo = () => async (dispatch: dispatch) => {
       verifications = [],
       connections = [],
     } = await api.getUserInfo();
-    dispatch(setEligibleGroups(eligibleGroups));
+    const oldEligibleGroups = [...getState().eligibleGroups];
+    const remained = oldEligibleGroups.filter( function( el ) {
+      return (! eligibleGroups.some(x => x.id == el.id) && ! currentGroups.some(x => x.id == el.id))
+    });
+    dispatch(setEligibleGroups([...remained, ...eligibleGroups]));
     dispatch(setCurrentGroups(currentGroups));
     dispatch(setUserScore(__DEV__ ? 100 : score));
     dispatch(setGroupsCount(currentGroups.length));

--- a/BrightID/src/actions/index.js
+++ b/BrightID/src/actions/index.js
@@ -3,6 +3,7 @@
 export const USER_SCORE = 'USER_SCORE';
 export const GROUPS_COUNT = 'GROUPS_COUNT';
 export const SEARCH_PARAM = 'SEARCH_PARAM';
+export const CREATE_GROUP = 'CREATE_GROUP';
 export const SET_NEW_GROUP_CO_FOUNDERS = 'SET_NEW_GROUP_CO_FOUNDERS';
 export const CLEAR_NEW_GROUP_CO_FOUNDERS = 'CLEAR_NEW_GROUP_CO_FOUNDERS';
 export const SET_ELIGIBLE_GROUPS = 'SET_ELIGIBLE_GROUPS';
@@ -72,6 +73,15 @@ export const setGroupsCount = (groupsCount: number) => ({
 export const setSearchParam = (searchParam: string) => ({
   type: SEARCH_PARAM,
   searchParam,
+});
+
+/**
+ * redux action creator for create new group
+ * @param group: new group
+ */
+export const createGroup = (group: group) => ({
+  type: CREATE_GROUP,
+  group,
 });
 
 /**

--- a/BrightID/src/components/GroupsScreens/EmptyGroups.js
+++ b/BrightID/src/components/GroupsScreens/EmptyGroups.js
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: '100%',
     height: '45%',
-    backgroundColor: '#fff',
+    backgroundColor: '#fcfcfc',
   },
   fullScreenContainer: {
     flex: 1,

--- a/BrightID/src/components/GroupsScreens/NewGroupCard.js
+++ b/BrightID/src/components/GroupsScreens/NewGroupCard.js
@@ -149,9 +149,6 @@ const styles = StyleSheet.create({
   },
 });
 
-export default connect(
-  null,
-  (dispatch) => ({
-    toggleCoFounder: (id) => dispatch(toggleNewGroupCoFounder(id)),
-  }),
-)(NewGroupCard);
+export default connect(null, (dispatch) => ({
+  toggleCoFounder: (id) => dispatch(toggleNewGroupCoFounder(id)),
+}))(NewGroupCard);

--- a/BrightID/src/components/GroupsScreens/actions.js
+++ b/BrightID/src/components/GroupsScreens/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import { Alert } from 'react-native';
-import { hash } from '../../utils/encoding';
+import { newGroupId } from '../../utils/groups';
 import {
   deleteEligibleGroup,
   joinGroup,
@@ -9,7 +9,6 @@ import {
   createGroup,
 } from '../../actions/index';
 import api from '../../Api/BrightId';
-import { addConnection } from '../../actions';
 
 export const toggleNewGroupCoFounder = (id: string) => (
   dispatch: dispatch,
@@ -29,7 +28,7 @@ export const createNewGroup = () => async (
   dispatch: dispatch,
   getState: getState,
 ) => {
-  let { id, newGroupCoFounders, eligibleGroups, currentGroups } = getState();
+  let { id, newGroupCoFounders } = getState();
   if (newGroupCoFounders.length < 2) {
     Alert.alert(
       'Cannot create group',
@@ -38,19 +37,14 @@ export const createNewGroup = () => async (
     return false;
   }
   try {
-    const existGroups = [...eligibleGroups, ...currentGroups]
-    const groupId = hash([id, newGroupCoFounders[0], newGroupCoFounders[1]].sort().join(','));
-    const found = existGroups.some(el => el.id === groupId);
-    if (found) {
-      throw new Error('Duplicate group');
-    }
+    const groupId = newGroupId();
     const newGroup = {
       founders: [id, newGroupCoFounders[0], newGroupCoFounders[1]],
       id: groupId,
       isNew: true,
       knownMembers: [id],
-      score: 0
-    }
+      score: 0,
+    };
     dispatch(createGroup(newGroup));
     return await api.createGroup(newGroupCoFounders[0], newGroupCoFounders[1]);
   } catch (err) {

--- a/BrightID/src/reducer/index.js
+++ b/BrightID/src/reducer/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { Alert } from 'react-native';
-import { dissoc, find, mergeRight, propEq } from 'ramda';
+import { dissoc, find, mergeRight, propEq, uniqBy } from 'ramda';
 import {
   USER_SCORE,
   GROUPS_COUNT,
@@ -18,7 +18,7 @@ import {
   SET_CONNECTIONS,
   CONNECTIONS_SORT,
   SET_USER_DATA,
-  USER_PHOTO,
+  SET_USER_PHOTO,
   SET_CONNECT_QR_DATA,
   REMOVE_CONNECT_QR_DATA,
   REMOVE_CONNECTION,
@@ -129,7 +129,7 @@ export const reducer = (state: State = initialState, action: action) => {
         groupsCount: action.groupsCount,
       };
     }
-    case USER_PHOTO: {
+    case SET_USER_PHOTO: {
       return {
         ...state,
         photo: action.photo,
@@ -162,7 +162,10 @@ export const reducer = (state: State = initialState, action: action) => {
     case SET_ELIGIBLE_GROUPS: {
       return {
         ...state,
-        eligibleGroups: action.eligibleGroups,
+        eligibleGroups: uniqBy(({ id }) => id, [
+          ...state.eligibleGroups,
+          ...action.eligibleGroups,
+        ]),
       };
     }
     case DELETE_ELIGIBLE_GROUP: {

--- a/BrightID/src/reducer/index.js
+++ b/BrightID/src/reducer/index.js
@@ -6,6 +6,7 @@ import {
   USER_SCORE,
   GROUPS_COUNT,
   SEARCH_PARAM,
+  CREATE_GROUP,
   SET_NEW_GROUP_CO_FOUNDERS,
   CLEAR_NEW_GROUP_CO_FOUNDERS,
   SET_ELIGIBLE_GROUPS,
@@ -138,6 +139,12 @@ export const reducer = (state: State = initialState, action: action) => {
       return {
         ...state,
         searchParam: action.searchParam,
+      };
+    }
+    case CREATE_GROUP: {
+      return {
+        ...state,
+        eligibleGroups: [...state.eligibleGroups.slice(0), action.group],
       };
     }
     case SET_NEW_GROUP_CO_FOUNDERS: {

--- a/BrightID/src/reducer/main.js
+++ b/BrightID/src/reducer/main.js
@@ -4,6 +4,7 @@ import {
   USER_SCORE,
   GROUPS_COUNT,
   SEARCH_PARAM,
+  CREATE_GROUP,
   SET_NEW_GROUP_CO_FOUNDERS,
   CLEAR_NEW_GROUP_CO_FOUNDERS,
   SET_ELIGIBLE_GROUPS,
@@ -123,6 +124,12 @@ export const mainReducer = (
         ...state,
         searchParam: action.searchParam,
       };
+    case CREATE_GROUP:
+      return {
+        ...state,
+        eligibleGroups: [...state.eligibleGroups.slice(0), action.group],
+      };
+    }
     case SET_NEW_GROUP_CO_FOUNDERS: {
       return {
         ...state,

--- a/BrightID/src/utils/encoding.js
+++ b/BrightID/src/utils/encoding.js
@@ -2,7 +2,7 @@
 
 import B64 from 'base64-js';
 import { Buffer } from 'buffer';
-import { createHash } from 'react-native-crypto';
+import CryptoJS from 'crypto-js';
 
 export function uInt8ArrayToB64(array: Uint8Array) {
   const b = Buffer.from(array);
@@ -43,9 +43,7 @@ export function b64ToUrlSafeB64(s: string) {
 }
 
 export function hash(data: string) {
-  const h = createHash('sha256')
-    .update(data)
-    .digest('hex');
-  const b = Buffer.from(h, 'hex').toString('base64');
+  const h = CryptoJS.SHA256(data);
+  const b = h.toString(CryptoJS.enc.Base64);
   return b64ToUrlSafeB64(b);
 }

--- a/BrightID/src/utils/encoding.js
+++ b/BrightID/src/utils/encoding.js
@@ -2,6 +2,7 @@
 
 import B64 from 'base64-js';
 import { Buffer } from 'buffer';
+import { createHash } from 'react-native-crypto';
 
 export function uInt8ArrayToB64(array: Uint8Array) {
   const b = Buffer.from(array);
@@ -39,4 +40,12 @@ export function b64ToUrlSafeB64(s: string) {
     '=': '',
   };
   return s.replace(/[/+=]/g, (c) => alts[c]);
+}
+
+export function hash(data: string) {
+  const h = createHash('sha256')
+    .update(data)
+    .digest('hex');
+  const b = Buffer.from(h, 'hex').toString('base64');
+  return b64ToUrlSafeB64(b);
 }

--- a/BrightID/src/utils/groups.js
+++ b/BrightID/src/utils/groups.js
@@ -1,4 +1,5 @@
 import store from '../store';
+import { hash } from './encoding';
 
 const memberList = (group) => {
   const { id, photo, name, connections } = store.getState();
@@ -82,4 +83,21 @@ export const getGroupName = (group) => {
   const names = memberList(group).map((member) => member.name.substr(0, 13));
 
   return names.join(', ');
+};
+
+export const newGroupId = () => {
+  const {
+    id,
+    newGroupCoFounders,
+    eligibleGroups,
+    currentGroups,
+  } = store.getState();
+  const existingGroups = [...eligibleGroups, ...currentGroups];
+  const groupId = hash(
+    [id, newGroupCoFounders[0], newGroupCoFounders[1]].sort().join(','),
+  );
+  if (existingGroups.some((el) => el.id === groupId)) {
+    throw new Error('group already exists');
+  }
+  return groupId;
 };


### PR DESCRIPTION
After upgrading to BrightID-Node v3.0.0, as creating group requests will be applied to the database with a delay, we can not rely on the data that we query from the server, for listing the eligible groups in the groups' tab. Currently, users can not see the groups after founding them on the groups' screen and think that there is a problem there.
To solve this issue, we should add the newly founded groups to the local redux storage and rely on this local data instead of remote data for showing groups just like what we have for connections.
This is what is implemented in this branch.