### PR TITLE
resolved #251, show the connections' status

### DIFF
--- a/BrightID/src/actions/fakeContact.js
+++ b/BrightID/src/actions/fakeContact.js
@@ -41,6 +41,7 @@ export const addConnection = (navigation: navigation) => async (
     name,
     score,
     photo: 'https://loremflickr.com/180/180/all',
+    status: 'initiated',
   };
 
   RNFetchBlob.fetch('GET', 'https://loremflickr.com/180/180/all', {})

--- a/BrightID/src/actions/fetchUserInfo.js
+++ b/BrightID/src/actions/fetchUserInfo.js
@@ -7,7 +7,7 @@ import {
   setGroupsCount,
   setUserScore,
   setVerifications,
-  updateConnectionScores,
+  updateConnections,
 } from './index';
 
 // TODO update connections here
@@ -25,7 +25,7 @@ const fetchUserInfo = () => async (dispatch: dispatch, getState: getState) => {
     dispatch(setUserScore(__DEV__ ? 100 : score));
     dispatch(setGroupsCount(currentGroups.length));
     dispatch(setVerifications(verifications));
-    dispatch(updateConnectionScores(connections));
+    dispatch(updateConnections(connections));
   } catch (err) {
     err instanceof Error ? console.warn(err.message) : console.log(err);
   }

--- a/BrightID/src/actions/index.js
+++ b/BrightID/src/actions/index.js
@@ -34,7 +34,7 @@ export const SET_RECOVERY_DATA = 'SET_RECOVERY_DATA';
 export const REMOVE_RECOVERY_DATA = 'REMOVE_RECOVERY_DATA';
 export const SET_HASHED_ID = 'SET_HASHED_ID';
 export const UPDATE_CONNECTION = 'UPDATE_CONNECTION';
-export const UPDATE_CONNECTION_SCORES = 'UPDATE_CONNECTION_SCORES';
+export const UPDATE_CONNECTIONS = 'UPDATE_CONNECTIONS';
 export const ADD_CONNECTION = 'ADD_CONNECTION';
 export const SET_USER_ID = 'SET_USER_ID';
 export const HYDRATE_STATE = 'HYDRATE_STATE';
@@ -346,9 +346,9 @@ export const resetStore = () => ({
   type: RESET_STORE,
 });
 
-export const updateConnectionScores = (
-  connections: Array<{ id: string, score: number }>,
+export const updateConnections = (
+  connections: Array<{ id: string, score: number, status: string }>,
 ) => ({
-  type: UPDATE_CONNECTION_SCORES,
+  type: UPDATE_CONNECTIONS,
   connections,
 });

--- a/BrightID/src/components/Connections/ConnectionCard.js
+++ b/BrightID/src/components/Connections/ConnectionCard.js
@@ -70,6 +70,30 @@ class ConnectionCard extends React.PureComponent<Props> {
     }
   };
 
+  setStatus = () => {
+    const { score, status } = this.props;
+    if (status == 'initiated') {
+      return (
+        <View style={styles.scoreContainer}>
+          <Text style={styles.waitingMessage}>Waiting</Text>
+        </View>
+      );
+    } else if (status == 'deleted') {
+      return (
+        <View style={styles.scoreContainer}>
+          <Text style={styles.deletedMessage}>Deleted</Text>
+        </View>
+      );
+    } else {
+      return (
+        <View style={styles.scoreContainer}>
+          <Text style={styles.scoreLeft}>Score:</Text>
+          <Text style={[styles.scoreRight, this.scoreColor()]}>{score}</Text>
+        </View>
+      );
+    }
+  };
+
   render() {
     const { photo, name, connectionDate, score, style } = this.props;
 
@@ -83,10 +107,7 @@ class ConnectionCard extends React.PureComponent<Props> {
         />
         <View style={styles.info}>
           <Text style={styles.name}>{name}</Text>
-          <View style={styles.scoreContainer}>
-            <Text style={styles.scoreLeft}>Score:</Text>
-            <Text style={[styles.scoreRight, this.scoreColor()]}>{score}</Text>
-          </View>
+          <this.setStatus />
           <Text style={styles.connectedText}>
             Connected {moment(parseInt(connectionDate, 10)).fromNow()}
           </Text>
@@ -160,6 +181,16 @@ const styles = StyleSheet.create({
   },
   moreIcon: {
     marginRight: 16,
+  },
+  waitingMessage: {
+    fontFamily: 'ApexNew-Medium',
+    fontSize: 16,
+    color: '#e39f2f'
+  },
+  deletedMessage: {
+    fontFamily: 'ApexNew-Medium',
+    fontSize: 16,
+    color: '#FF0800',
   },
 });
 

--- a/BrightID/src/components/NewConnectionsScreens/actions/addNewConnection.js
+++ b/BrightID/src/components/NewConnectionsScreens/actions/addNewConnection.js
@@ -54,6 +54,7 @@ export const addNewConnection = () => async (
       secretKey: connectUserData.secretKey,
       connectionDate,
       photo: { filename },
+      status: 'initiated'
     };
 
     dispatch(addConnection(connectionData));

--- a/BrightID/src/reducer/index.js
+++ b/BrightID/src/reducer/index.js
@@ -42,7 +42,7 @@ import {
   REMOVE_SAFE_PUB_KEY,
   HYDRATE_STATE,
   RESET_STORE,
-  UPDATE_CONNECTION_SCORES,
+  UPDATE_CONNECTIONS,
 } from '../actions';
 import { verifyStore } from './verifyStoreV1';
 
@@ -230,14 +230,18 @@ export const reducer = (state: State = initialState, action: action) => {
         ],
       };
     }
-    case UPDATE_CONNECTION_SCORES: {
+    case UPDATE_CONNECTIONS: {
       return {
         ...state,
         connections: state.connections.map<connection>((conn: connection) => {
           const updatedConn = find(propEq('id', conn.id))(action.connections);
           if (!updatedConn) {
+            if (conn.status == 'verified') {
+              conn.status = 'deleted';
+            }
             return conn;
           } else {
+            conn.status = 'verified';
             return mergeRight(conn, updatedConn);
           }
         }),


### PR DESCRIPTION
After upgrading to BrightID-Node v3.0.0, the connections can be in 3 different states, initiated and waiting for confirmation, confirmed and deleted. So we should update local connections data every time we query the connections and show in the connections screen. It includes issue #251.