### PR TITLE
Sort Groups Tab by most recent by default

### DIFF
--- a/BrightID/src/components/GroupsScreens/GroupsScreen.js
+++ b/BrightID/src/components/GroupsScreens/GroupsScreen.js
@@ -17,6 +17,7 @@ import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import GroupCard from './GroupCard';
 import { NoGroups } from './NoGroups';
 import SearchGroups from './SearchGroups';
+import { compareJoinedDesc } from './models/sortingUtility';
 
 /**
  * Group screen of BrightID
@@ -170,6 +171,9 @@ function mapStateToProps(state) {
         .includes(searchParam),
     );
   }
+
+  // sort groups by joined timestamp, newest first
+  groups.sort(compareJoinedDesc);
 
   return { groups, hasGroups };
 }

--- a/BrightID/src/components/GroupsScreens/models/sortingUtility.js
+++ b/BrightID/src/components/GroupsScreens/models/sortingUtility.js
@@ -1,0 +1,3 @@
+export const compareJoinedDesc = (groupA, groupB) => {
+  return groupB.joined - groupA.joined;
+};

--- a/BrightID/src/reducer/groups.js
+++ b/BrightID/src/reducer/groups.js
@@ -18,30 +18,6 @@ import {
 } from '@/actions';
 import { INVITE_ACCEPTED, INVITE_REJECTED } from '@/utils/constants';
 
-/* ******** HELPERS ****************** */
-
-const byPrimaryGroup = (a, b) => {
-  if (a.type === 'primary') {
-    return -1;
-  } else if (b.type === 'primary') {
-    return 1;
-  } else {
-    return 0;
-  }
-};
-
-const byIsNew = (a, b) => {
-  if (a.isNew && b.isNew) {
-    return 0;
-  } else if (a.isNew) {
-    return 1;
-  } else if (b.isNew) {
-    return -1;
-  } else {
-    return 0;
-  }
-};
-
 /* ******** INITIAL STATE ************** */
 
 export const initialState = {
@@ -62,10 +38,7 @@ export const reducer = (state: GroupsState = initialState, action: action) => {
       };
     }
     case CREATE_GROUP: {
-      const groups: group[] = state.groups
-        .concat(action.group)
-        .sort(byPrimaryGroup)
-        .sort(byIsNew);
+      const groups: group[] = state.groups.concat(action.group);
       return {
         ...state,
         groups,
@@ -103,10 +76,7 @@ export const reducer = (state: GroupsState = initialState, action: action) => {
         return group;
       };
 
-      const groups = action.groups
-        .map(mergeWithOld)
-        .sort(byPrimaryGroup)
-        .sort(byIsNew);
+      const groups = action.groups.map(mergeWithOld);
       return {
         ...state,
         groups,
@@ -145,10 +115,7 @@ export const reducer = (state: GroupsState = initialState, action: action) => {
         action.group.isNew = false;
       }
 
-      const groups: group[] = state.groups
-        .concat(action.group)
-        .sort(byPrimaryGroup)
-        .sort(byIsNew);
+      const groups: group[] = state.groups.concat(action.group);
 
       return {
         ...state,


### PR DESCRIPTION
This should fix #372. Groups are now sorted only based on joinDate, starting with most recently joined group.

@RnbWd I moved the sorting logic from redux store to the UI layer as we had shortly discussed. Let me know if this looks good for you!