### PR TITLE
feat: Filter groups by name of user in group

### DIFF
--- a/BrightID/src/components/GroupsScreens/GroupsScreen.js
+++ b/BrightID/src/components/GroupsScreens/GroupsScreen.js
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 import fetchUserInfo from '@/actions/fetchUserInfo';
-import { getGroupName } from '@/utils/groups';
+import { getGroupName, ids2connections, knownMemberIDs } from '@/utils/groups';
 import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import GroupCard from './GroupCard';
 import { NoGroups } from './NoGroups';
@@ -164,11 +164,28 @@ function mapStateToProps(state) {
   // apply search filter to groups array
   // NOTE: If below sorting/filtering gets too expensive at runtime use memoized selectors / reselect
   if (searchParam !== '') {
-    groups = groups.filter((group) =>
-      getGroupName(group)
-        .toLowerCase()
-        .includes(searchParam),
-    );
+    groups = groups.filter((group) => {
+      if (
+        getGroupName(group)
+          .toLowerCase()
+          .includes(searchParam)
+      ) {
+        // direct group name match
+        return true;
+      } else {
+        // check group members
+        const allMemberNames = ids2connections(
+          knownMemberIDs(group),
+        ).map((member) => member.name.toLowerCase());
+        for (const name of allMemberNames) {
+          if (name.includes(searchParam)) {
+            // stop looking if a match is found
+            return true;
+          }
+        }
+        return false;
+      }
+    });
   }
 
   return { groups, hasGroups };

--- a/BrightID/src/components/GroupsScreens/SearchGroups.js
+++ b/BrightID/src/components/GroupsScreens/SearchGroups.js
@@ -34,7 +34,7 @@ class SearchGroups extends React.Component<Props & LocalProps> {
         <TextInput
           onChangeText={(value) => this.props.dispatch(setGroupSearch(value))}
           style={styles.searchField}
-          placeholder="Search Groups"
+          placeholder="Search by group or member name"
           autoCapitalize="words"
           autoCorrect={false}
           textContentType="name"

--- a/BrightID/src/utils/groups.js
+++ b/BrightID/src/utils/groups.js
@@ -63,3 +63,20 @@ export const ids2connections = (ids) => {
     }
   });
 };
+
+export const knownMemberIDs = (group) => {
+  const {
+    connections: { connections },
+  } = store.getState();
+  // only members that are in my connections are known
+  let knownMemberIDs = group.members.filter((memberId) =>
+    connections.find((connection) => connection.id === memberId),
+  );
+  if (group.isNew) {
+    // explicitly add founderIDs as they might not have joined yet
+    knownMemberIDs = knownMemberIDs.concat(group.founders);
+    // make sure array is unique
+    knownMemberIDs = [...new Set(knownMemberIDs)];
+  }
+  return knownMemberIDs;
+};


### PR DESCRIPTION
Extend group filter to take member names into account.
When you enter a search string it will now match against the group name and group members.

This should fix #273.