### PR TITLE
Linking to apps is broken

### DIFF
--- a/BrightID/src/components/Apps/model.js
+++ b/BrightID/src/components/Apps/model.js
@@ -21,11 +21,12 @@ type ContextInfo = {
 
 export const handleAppContext = async (params: Params) => {
   // if 'params' is defined, the user came through a deep link
+  params.baseUrl = decodeURIComponent(params.baseUrl);
   const { baseUrl, context, contextId } = params;
   const oldBaseUrl = api.baseUrl;
   let contextInfo;
   try {
-    api.baseUrl = decodeURIComponent(baseUrl);
+    api.baseUrl = baseUrl;
     contextInfo = await api.getContext(context);
   } catch (e) {
     console.log(e.message);

--- a/BrightID/src/components/Apps/model.js
+++ b/BrightID/src/components/Apps/model.js
@@ -25,7 +25,7 @@ export const handleAppContext = async (params: Params) => {
   const oldBaseUrl = api.baseUrl;
   let contextInfo;
   try {
-    api.baseUrl = baseUrl;
+    api.baseUrl = decodeURIComponent(baseUrl);
     contextInfo = await api.getContext(context);
   } catch (e) {
     console.log(e.message);


### PR DESCRIPTION
Linking to apps is broken.  Something must have been decoding urls automatically and an upgrade changed that behavior.

@RnbWd This hotfix should be released to app stores immediately.

Feel free to bump versions in this hotfix branch or in master after it's merged.