### PR TITLE
fix: learn more button now opens url

### DIFF
--- a/BrightID/src/components/GroupsScreens/NoGroups.js
+++ b/BrightID/src/components/GroupsScreens/NoGroups.js
@@ -1,12 +1,23 @@
 // @flow
 
 import * as React from 'react';
-import { View, Image, StyleSheet, Text, TouchableOpacity } from 'react-native';
-import emitter from '@/emitter';
+import {
+  View,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
 import { DEVICE_TYPE } from '@/utils/constants';
 
-const showWhitePaper = () => {
-  emitter.emit('showWhitePaper');
+const learnMoreUrl =
+  'https://docs.google.com/document/d/1CEBWv4ImXsZYQ2Qll7BXojeKI9CGtzRXjB9aFIj00c4/edit#heading=h.nr1odgliy5nk';
+
+const handleLearnMore = () => {
+  Linking.openURL(learnMoreUrl).catch((err) =>
+    console.error(`Failed to open "${learnMoreUrl}", error was: ${err}`),
+  );
 };
 
 export const NoGroups = ({ navigation }: Props) => (
@@ -29,7 +40,11 @@ export const NoGroups = ({ navigation }: Props) => (
       </View>
     </View>
     <View style={styles.emptyButtons}>
-      <TouchableOpacity testID="groupsLearnMoreBtn" style={styles.learnMoreButton} onPress={showWhitePaper}>
+      <TouchableOpacity
+        testID="groupsLearnMoreBtn"
+        style={styles.learnMoreButton}
+        onPress={handleLearnMore}
+      >
         <Text style={styles.learnMoreText}>Learn More</Text>
       </TouchableOpacity>
       <TouchableOpacity


### PR DESCRIPTION
Should fix #277

I don't think there is need to go through emitter, so I replaced it with Linking.openURL.