### PR TITLE
Handle waiting and deleted connections

### DIFF
--- a/BrightID/src/Api/BrightId.js
+++ b/BrightID/src/Api/BrightId.js
@@ -373,9 +373,12 @@ class BrightId {
   async getOperationState(opHash: string) {
     let res = await this.api.get(`/operations/${opHash}`);
     if (res.status === 404) {
-      // operation is not known. Don't throw an error, as a client might try to check
-      // operations sent by other clients without knowing if they have been submitted already
-      return undefined;
+      // operation is not existing on server. Don't throw an error, as a client might try to check
+      // operations sent by other clients without knowing if they have been submitted already.
+      return {
+        state: 'unknown',
+        result: '',
+      };
     }
     BrightId.throwOnError(res);
     return res.data.data;

--- a/BrightID/src/Api/BrightId.js
+++ b/BrightID/src/Api/BrightId.js
@@ -76,6 +76,7 @@ class BrightId {
 
     let res = await this.api.put(`/operations/${op._key}`, op);
     BrightId.throwOnError(res);
+    console.log(`Initiator opMessage: ${message} - hash: ${hash(message)}`);
     BrightId.setOperation(op);
   }
 
@@ -371,6 +372,11 @@ class BrightId {
 
   async getOperationState(opHash: string) {
     let res = await this.api.get(`/operations/${opHash}`);
+    if (res.status === 404) {
+      // operation is not known. Don't throw an error, as a client might try to check
+      // operations sent by other clients without knowing if they have been submitted already
+      return undefined;
+    }
     BrightId.throwOnError(res);
     return res.data.data;
   }

--- a/BrightID/src/App.js
+++ b/BrightID/src/App.js
@@ -35,7 +35,6 @@ export const App = () => {
   useEffect(() => {
     const timerId = setInterval(() => {
       pollOperations();
-      console.log('polling operations');
     }, 5000);
     return () => {
       clearInterval(timerId);

--- a/BrightID/src/components/Connections/ConnectionCard.js
+++ b/BrightID/src/components/Connections/ConnectionCard.js
@@ -6,7 +6,7 @@ import RNFS from 'react-native-fs';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import Material from 'react-native-vector-icons/MaterialCommunityIcons';
-import { DEVICE_TYPE } from '@/utils/constants';
+import { DEVICE_TYPE, MAX_WAITING_SECONDS } from '@/utils/constants';
 
 /**
  * Connection Card in the Connections Screen
@@ -37,11 +37,17 @@ class ConnectionCard extends React.PureComponent<Props> {
   };
 
   setStatus = () => {
-    const { score, status } = this.props;
+    const { score, status, connectionDate } = this.props;
     if (status === 'initiated') {
+      const ageSeconds = Math.floor((Date.now() - connectionDate) / 1000);
+      console.log(`Connection age: ${ageSeconds} seconds`);
+      let statusText = 'Waiting';
+      if (ageSeconds > MAX_WAITING_SECONDS) {
+        statusText = 'Connection failed. Please try again.';
+      }
       return (
         <View style={styles.scoreContainer}>
-          <Text style={styles.waitingMessage}>Waiting</Text>
+          <Text style={styles.waitingMessage}>{statusText}</Text>
         </View>
       );
     } else if (status === 'verified') {

--- a/BrightID/src/components/Connections/ConnectionCard.js
+++ b/BrightID/src/components/Connections/ConnectionCard.js
@@ -43,13 +43,13 @@ class ConnectionCard extends React.Component<Props, State> {
         // this is already old. Immediately mark as "stale", no need for a timer.
         this.setState({ isStale: true });
       } else {
+        // start timer to check if connection got verified after MAX_WAITING_TIME
         let checkTime =
           connectionDate + MAX_WAITING_SECONDS * 1000 + 5000 - Date.now(); // add 5 seconds buffer
         if (checkTime < 0) {
           console.log(`Warning - checkTime in past: ${checkTime}`);
           checkTime = 1000; // check in 1 second
         }
-        // start timer to check if connection got verified after MAX_WAITING_TIME
         console.log(`Checking connection state in ${checkTime}ms.`);
         clearTimeout(this.state.stale_check_timer);
         const stale_check_timer = setTimeout(() => {
@@ -64,7 +64,11 @@ class ConnectionCard extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    if (prevProps.status === 'initiated' && this.props.status === 'verified') {
+    if (
+      this.state.stale_check_timer &&
+      prevProps.status === 'initiated' &&
+      this.props.status === 'verified'
+    ) {
       console.log(
         `Connection ${this.props.name} changed to 'verified'. Stopping timer.`,
       );
@@ -171,7 +175,6 @@ class ConnectionCard extends React.Component<Props, State> {
 
   render() {
     const { photo, name, connectionDate, style } = this.props;
-    console.log(`Rendering connection ${name}`);
     const connectionStatus = this.getStatus();
     const contextAction = this.getContextAction();
 

--- a/BrightID/src/components/Connections/ConnectionsScreen.js
+++ b/BrightID/src/components/Connections/ConnectionsScreen.js
@@ -75,23 +75,44 @@ export class ConnectionsScreen extends React.Component<Props, State> {
     );
   };
 
-  handleRemoveWaitingConnection = (connection) => {
-    // show confirmation dialog before actually removing...
+  handleRemoveStaleConnection = (connection) => {
     if (connection.status !== 'initiated') {
       console.log(
         `Cant remove connection ${connection.id} with status ${connection.status}.`,
       );
-    } else {
-      console.log(`Removing connection ${connection.id} (${connection.name})`);
-      const { dispatch } = this.props;
-      dispatch(deleteConnection(connection.id));
+      return;
     }
+
+    const buttons = [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'OK',
+        onPress: () => {
+          console.log(
+            `Removing connection ${connection.id} (${connection.name})`,
+          );
+          const { dispatch } = this.props;
+          dispatch(deleteConnection(connection.id));
+        },
+      },
+    ];
+    Alert.alert(
+      `Remove waiting connection`,
+      `Are you sure you want to stop waiting for connection with ${connection.name}? You can retry connecting anytime.`,
+      buttons,
+      {
+        cancelable: true,
+      },
+    );
   };
 
   renderConnection = ({ item }) => (
     <ConnectionCard
       actionSheet={this.actionSheet}
-      onDelete={this.handleRemoveWaitingConnection}
+      onRemove={this.handleRemoveStaleConnection}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...item}
     />

--- a/BrightID/src/components/Connections/ConnectionsScreen.js
+++ b/BrightID/src/components/Connections/ConnectionsScreen.js
@@ -75,10 +75,10 @@ export class ConnectionsScreen extends React.Component<Props, State> {
     );
   };
 
-  handleRemoveStaleConnection = (connection) => {
-    if (connection.status !== 'initiated') {
+  handleRemoveConnection = (connection) => {
+    if (connection.status === 'verified') {
       console.log(
-        `Cant remove connection ${connection.id} with status ${connection.status}.`,
+        `Cant remove verified connection ${connection.id} (${connection.name}).`,
       );
       return;
     }
@@ -100,8 +100,8 @@ export class ConnectionsScreen extends React.Component<Props, State> {
       },
     ];
     Alert.alert(
-      `Remove waiting connection`,
-      `Are you sure you want to stop waiting for connection with ${connection.name}? You can retry connecting anytime.`,
+      `Remove connection`,
+      `Are you sure you want to remove connection with ${connection.name}? You can reconnect anytime.`,
       buttons,
       {
         cancelable: true,
@@ -112,7 +112,7 @@ export class ConnectionsScreen extends React.Component<Props, State> {
   renderConnection = ({ item }) => (
     <ConnectionCard
       actionSheet={this.actionSheet}
-      onRemove={this.handleRemoveStaleConnection}
+      onRemove={this.handleRemoveConnection}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...item}
     />

--- a/BrightID/src/components/Connections/ConnectionsScreen.js
+++ b/BrightID/src/components/Connections/ConnectionsScreen.js
@@ -14,6 +14,7 @@ import ActionSheet from 'react-native-actionsheet';
 import fetchUserInfo from '@/actions/fetchUserInfo';
 import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import EmptyList from '@/components/Helpers/EmptyList';
+import { deleteConnection } from '@/actions';
 import SearchConnections from './SearchConnections';
 import ConnectionCard from './ConnectionCard';
 import { createFakeConnection } from './models/createFakeConnection';
@@ -74,9 +75,26 @@ export class ConnectionsScreen extends React.Component<Props, State> {
     );
   };
 
+  handleRemoveWaitingConnection = (connection) => {
+    // show confirmation dialog before actually removing...
+    if (connection.status !== 'initiated') {
+      console.log(
+        `Cant remove connection ${connection.id} with status ${connection.status}.`,
+      );
+    } else {
+      console.log(`Removing connection ${connection.id} (${connection.name})`);
+      const { dispatch } = this.props;
+      dispatch(deleteConnection(connection.id));
+    }
+  };
+
   renderConnection = ({ item }) => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <ConnectionCard actionSheet={this.actionSheet} {...item} />
+    <ConnectionCard
+      actionSheet={this.actionSheet}
+      onDelete={this.handleRemoveWaitingConnection}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...item}
+    />
   );
 
   modifyConnection = (option: string) => {

--- a/BrightID/src/components/NewConnectionsScreens/actions/profile.js
+++ b/BrightID/src/components/NewConnectionsScreens/actions/profile.js
@@ -81,7 +81,6 @@ export const fetchProfile = (qrCodeData) => async (
 
     if (profileData && profileData.data) {
       try {
-        console.log(`fetched profile: ${profileData.data}`);
         emitter.emit('recievedProfileData');
         // workaround: For now stop polling for profiles after the first profile is received,
         //  otherwise the same profile(s) will be downloaded again and again

--- a/BrightID/src/utils/constants.js
+++ b/BrightID/src/utils/constants.js
@@ -37,4 +37,4 @@ export const QR_TTL = 900000;
 export const PROFILE_POLL_INTERVAL = 1000;
 export const QR_TYPE_INITIATOR = 'initiator';
 export const QR_TYPE_RESPONDER = 'responder';
-export const MAX_WAITING_SECONDS = 60;
+export const MAX_WAITING_SECONDS = 30;

--- a/BrightID/src/utils/constants.js
+++ b/BrightID/src/utils/constants.js
@@ -37,3 +37,4 @@ export const QR_TTL = 900000;
 export const PROFILE_POLL_INTERVAL = 1000;
 export const QR_TYPE_INITIATOR = 'initiator';
 export const QR_TYPE_RESPONDER = 'responder';
+export const MAX_WAITING_SECONDS = 60;

--- a/BrightID/src/utils/constants.js
+++ b/BrightID/src/utils/constants.js
@@ -37,4 +37,4 @@ export const QR_TTL = 900000;
 export const PROFILE_POLL_INTERVAL = 1000;
 export const QR_TYPE_INITIATOR = 'initiator';
 export const QR_TYPE_RESPONDER = 'responder';
-export const MAX_WAITING_SECONDS = 30;
+export const MAX_WAITING_SECONDS = 60;

--- a/BrightID/src/utils/cryptoHelper.js
+++ b/BrightID/src/utils/cryptoHelper.js
@@ -11,7 +11,6 @@ export const decryptData = (data, aesKey) => {
   const decrypted = CryptoJS.AES.decrypt(data, aesKey).toString(
     CryptoJS.enc.Utf8,
   );
-  console.log(`Decrypted data: ${decrypted}`);
   const decryptedObj = JSON.parse(decrypted);
   decryptedObj.aesKey = aesKey;
   return decryptedObj;

--- a/BrightID/src/utils/operations.js
+++ b/BrightID/src/utils/operations.js
@@ -8,41 +8,54 @@ import api from '../Api/BrightId';
 
 const time_fudge = 2 * 60 * 1000; // trace operations for 2 minutes
 
+const handleOpUpdate = (store, op, state, result) => {
+  switch (op.name) {
+    case 'Link ContextId':
+      store.dispatch(updateApp(op, state, result));
+      if (state === 'applied')
+        Alert.alert(
+          'Success',
+          `Succesfully linked ${op.context} with BrightID`,
+        );
+      break;
+    default:
+      store.dispatch(fetchUserInfo());
+  }
+};
+
 export const pollOperations = async () => {
   const {
     operations: { operations },
   } = store.getState();
   try {
     for (const op of operations) {
-      const opState = await api.getOperationState(op._key);
-      if (!opState) {
-        console.log(`operation ${op._key} not found on server`);
-        // operation is not known on the api. Just check the timestamp and move on.
-        if (op.timestamp + time_fudge < Date.now()) {
-          // op is expired. Remove from watchlist.
-          store.dispatch(removeOperation(op._key));
-        }
-      } else {
-        const { state, result } = opState;
-        if (
-          state === 'applied' ||
-          state === 'failed' ||
-          op.timestamp + time_fudge < Date.now()
-        ) {
-          if (op.name === 'Link ContextId') {
-            store.dispatch(updateApp(op, state, result));
-            if (state === 'applied')
-              Alert.alert(
-                'Success',
-                `Succesfully linked ${op.context} with BrightID`,
-              );
-          } else {
-            store.dispatch(fetchUserInfo());
-          }
-          store.dispatch(removeOperation(op._key));
-        } else if (state !== 'sent') {
-          console.log(`${state} is an invalid state!`);
-        }
+      const { state, result } = await api.getOperationState(op._key);
+
+      // stop polling for op if trace time is expired
+      let removeOp = op.timestamp + time_fudge < Date.now();
+
+      switch (state) {
+        case 'unknown':
+          // Op not found on server. It might appear in a future poll cycle, so do nothing.
+          console.log(`operation ${op.name} (${op._key}) unknown on server`);
+          break;
+        case 'init':
+        case 'sent':
+          // Op still waiting to be processed. Do nothing.
+          break;
+        case 'applied':
+        case 'failed':
+          // op is done, so stop polling for it
+          removeOp = true;
+          handleOpUpdate(store, op, state, result);
+          break;
+        default:
+          console.log(
+            `Op ${op.name} (${op._key}) has invalid state '${state}'!`,
+          );
+      }
+      if (removeOp) {
+        store.dispatch(removeOperation(op._key));
       }
     }
   } catch (err) {


### PR DESCRIPTION
Changes:
- Don't show flag button for connections in waiting state
- Track 'Add Connection' operation also on the responder side (the person that scanned other persons code). This makes the connection change automatically from 'waiting' to 'connected'. 
- If a connection is in waiting state for more than 1 minute mark it as stale:
  - update the connection label to "Connection failed. Please try again".
  - add an 'X' button to the connection that enables to remove the stale connection (after confirmation)
- If a connection is in "deleted" state (you have been flagged by the other person), also show the 'X' button instead of the flag button, so you can remove the deleted connection

This should fix #364 and partly deals with #311.