### PR TITLE
feat: show backend error message when linking fails

### DIFF
--- a/BrightID/src/components/Apps/AppCard.js
+++ b/BrightID/src/components/Apps/AppCard.js
@@ -54,7 +54,7 @@ class AppCard extends React.PureComponent<Props, State> {
   };
 
   linkLabel = () => {
-    const { state } = this.props;
+    const { state, result } = this.props;
     if (state === 'initiated') {
       return (
         <View style={styles.stateContainer}>
@@ -62,9 +62,12 @@ class AppCard extends React.PureComponent<Props, State> {
         </View>
       );
     } else if (state === 'failed') {
+      const errorMessage = result
+        ? `Not linked: ${result}.`
+        : `Not Linked, try again`;
       return (
         <View style={styles.stateContainer}>
-          <Text style={styles.errorMessage}>Not Linked, try again</Text>
+          <Text style={styles.errorMessage}>{errorMessage}</Text>
         </View>
       );
     } else {

--- a/BrightID/src/reducer/apps.js
+++ b/BrightID/src/reducer/apps.js
@@ -44,6 +44,11 @@ export const reducer = (state: AppsState = initialState, action: action) => {
         } else {
           updatedApp.state = 'failed';
         }
+        // Only store first line of result. BrightID node might attach stack trace
+        // to the failed op result.
+        updatedApp.result = action.result
+          ? action.result.split(/\r?\n/)[0]
+          : undefined;
         const removeExisting = ({ name }) => name !== action.op.context;
         apps = state.apps.filter(removeExisting).concat(updatedApp);
       } else {


### PR DESCRIPTION
Should fix #427

If you try to link to an contextID that is already used by another BrightID you will now get the backend error message displayed:

![image](https://user-images.githubusercontent.com/754478/84499529-13d3ea00-acb3-11ea-8aac-1273fecb0906.png)
