### PR TITLE
fix: clear navigation history when dismissing Success screen

### DIFF
--- a/BrightID/src/components/NewConnectionsScreens/SuccessScreen.js
+++ b/BrightID/src/components/NewConnectionsScreens/SuccessScreen.js
@@ -52,7 +52,11 @@ export const SuccessScreen = ({ navigation }) => {
           onPress={() => {
             dispatch(removeConnectUserData());
             dispatch(sortByDateAddedDescending());
-            navigation.navigate('Connections');
+            // clear navigation history to prevent going back to confirmation and preview screens with back button
+            navigation.reset({
+              index: 1,
+              routes: [{ name: 'Home' }, { name: 'Connections' }],
+            });
           }}
           style={styles.confirmButton}
         >


### PR DESCRIPTION
Fixes #445 

@RnbWd I don't really like the manual reconstruction of the navigation stack with the reset method. I only had a short look at the navigation API, so feel free to close this if you know a better way :-) 