### PR TITLE
Handle channel errors

### DIFF
--- a/BrightID/src/api/channelService.js
+++ b/BrightID/src/api/channelService.js
@@ -42,8 +42,8 @@ class ChannelAPI {
     if (response.ok) {
       return;
     }
-    if (response.data && response.data.errorMessage) {
-      throw new Error(response.data.errorMessage);
+    if (response.data && response.data.error) {
+      throw new Error(response.data.error);
     }
     throw new Error(response.problem);
   }

--- a/BrightID/src/api/channelService.test.js
+++ b/BrightID/src/api/channelService.test.js
@@ -50,4 +50,37 @@ describe('ChannelAPI', () => {
       expect(data).toMatchObject(myData);
     });
   });
+
+  describe(`Channel limit`, () => {
+    const channel_limit = 30;
+    const channelId = generateRandomString();
+
+    beforeAll(async () => {
+      // fill channel up to limit
+      for (let i = 0; i < channel_limit; i++) {
+        await channelApi.upload({
+          channelId,
+          dataId: generateRandomString(),
+          data: {
+            somekey: `value ${i}`,
+          },
+        });
+      }
+      // check if all entries are there
+      const list = await channelApi.list(channelId);
+      expect(list).toHaveLength(channel_limit);
+    });
+
+    test(`Adding more than ${channel_limit} entries to channel fails`, async () => {
+      await expect(
+        channelApi.upload({
+          channelId,
+          dataId: generateRandomString(),
+          data: {
+            somekey: `random data`,
+          },
+        }),
+      ).rejects.toThrow('Channel full');
+    });
+  });
 });

--- a/BrightID/src/utils/constants.js
+++ b/BrightID/src/utils/constants.js
@@ -30,7 +30,7 @@ export const BACKUP_URL = 'https://explorer.brightid.org';
 
 // CONNECTION CONSTANTS
 export const CHANNEL_TTL = 900000; // 15 minutes
-export const CHANNEL_CONNECTION_LIMIT = 15; // maximum number of connections allowed in channel.
+export const CHANNEL_CONNECTION_LIMIT = 30; // maximum number of connections allowed in channel.
 export const MIN_CHANNEL_JOIN_TTL = 5000;
 export const PROFILE_POLL_INTERVAL = 1000;
 export const QR_TYPE_INITIATOR = 'initiator';


### PR DESCRIPTION
If creating new or joining existing channel fails (e.g. because profile upload failed):
 - show an Alert to the user with error message
 - dispatch(leaveChannel) to have a consistent state
