### PR TITLE
(Patch) Opening Explorer Link 

### DIFF
--- a/BrightID/src/components/SideMenu/GraphExplorerScreen.js
+++ b/BrightID/src/components/SideMenu/GraphExplorerScreen.js
@@ -69,7 +69,7 @@ export const GraphExplorerScreen = function () {
         <Text style={styles.infoText}>
           <Text
             onPress={() => {
-              Linking.openURL("https://explorer.brightid.org/");
+              Linking.openURL('https://explorer.brightid.org/');
             }}
             style={styles.linkText}
           >

--- a/BrightID/src/components/SideMenu/GraphExplorerScreen.js
+++ b/BrightID/src/components/SideMenu/GraphExplorerScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { Text, StyleSheet, View, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, View, TouchableOpacity, Linking } from 'react-native';
 import Clipboard from '@react-native-community/clipboard';
 import { DEVICE_LARGE, DEVICE_IOS } from '@/utils/constants';
 import { useHeaderHeight } from '@react-navigation/stack';
@@ -69,7 +69,7 @@ export const GraphExplorerScreen = function () {
         <Text style={styles.infoText}>
           <Text
             onPress={() => {
-              alert('pressed!');
+              Linking.openURL("https://explorer.brightid.org/");
             }}
             style={styles.linkText}
           >


### PR DESCRIPTION
When you click on the explorer link it opens an alert instead of opening the device browser to show the explorer. 

This should fix that, My Apologies if there's an issue with syntax or if the implementation could be better, I've never worked with React 😄 