### PR TITLE
[f/519] Accent/Case/Space Insensitive Searches

### DIFF
--- a/BrightID/src/components/Connections/ConnectionsScreen.js
+++ b/BrightID/src/components/Connections/ConnectionsScreen.js
@@ -17,6 +17,7 @@ import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { deleteConnection } from '@/actions';
 import { ORANGE, DEVICE_LARGE, LIGHTBLUE } from '@/utils/constants';
+import { toSearchString } from '@/utils/strings';
 import Material from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import ConnectionCard from './ConnectionCard';
@@ -220,9 +221,9 @@ const filterConnectionsSelector = createSelector(
   connectionsSelector,
   searchParamSelector,
   (connections, searchParam) => {
-    const searchString = searchParam.toLowerCase().replace(/\s/g, '');
-    return connections.filter((item) =>
-      `${item.name}`.toLowerCase().replace(/\s/g, '').includes(searchString),
+    const searchString = toSearchString(searchParam);
+    return connections.filter((item) => 
+      toSearchString(`${item.name}`).includes(searchString),
     );
   },
 );

--- a/BrightID/src/components/GroupsScreens/GroupsScreen.js
+++ b/BrightID/src/components/GroupsScreens/GroupsScreen.js
@@ -15,6 +15,7 @@ import fetchUserInfo from '@/actions/fetchUserInfo';
 import { getGroupName, ids2connections, knownMemberIDs } from '@/utils/groups';
 import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import { ORANGE, DEVICE_LARGE } from '@/utils/constants';
+import { toSearchString } from '@/utils/strings';
 import GroupCard from './GroupCard';
 import { NoGroups } from './NoGroups';
 import { compareJoinedDesc } from './models/sortingUtility';
@@ -168,7 +169,7 @@ const styles = StyleSheet.create({
 
 function mapStateToProps(state) {
   const { groups: unfilteredGroups } = state.groups;
-  const searchParam = state.groups.searchParam.toLowerCase();
+  const searchParam = toSearchString(state.groups.searchParam);
   const hasGroups = unfilteredGroups.length > 0;
 
   // apply search filter to groups array
@@ -177,14 +178,14 @@ function mapStateToProps(state) {
   let groups;
   if (searchParam !== '') {
     groups = unfilteredGroups.filter((group) => {
-      if (getGroupName(group).toLowerCase().includes(searchParam)) {
+      if (toSearchString(getGroupName(group)).includes(searchParam)) {
         // direct group name match
         return true;
       } else {
         // check group members
         const allMemberNames = ids2connections(
           knownMemberIDs(group),
-        ).map((member) => member.name.toLowerCase());
+        ).map((member) => toSearchString(member.name));
         for (const name of allMemberNames) {
           if (name.includes(searchParam)) {
             // stop looking if a match is found

--- a/BrightID/src/components/GroupsScreens/NewGroups/NewGroupScreen.js
+++ b/BrightID/src/components/GroupsScreens/NewGroups/NewGroupScreen.js
@@ -11,6 +11,7 @@ import store from '@/store';
 import emitter from '@/emitter';
 import { clearNewGroupCoFounders } from '@/actions';
 import { DEVICE_TYPE, ORANGE, DEVICE_LARGE } from '@/utils/constants';
+import { toSearchString } from '@/utils/strings';
 import Spinner from 'react-native-spinkit';
 import { createNewGroup } from '../actions';
 import NewGroupCard from './NewGroupCard';
@@ -55,11 +56,9 @@ export class NewGroupScreen extends React.Component<Props> {
   filterConnections = () => {
     const { connections, searchParam } = this.props;
     return connections
-      .filter((item) =>
-        `${item.name}`
-          .toLowerCase()
-          .replace(/\s/g, '')
-          .includes(searchParam.toLowerCase().replace(/\s/g, '')),
+      .filter((item) => 
+        toSearchString(`${item.name}`)
+        .includes(toSearchString(searchParam)),
       )
       .filter((item) => item.status === 'verified');
   };

--- a/BrightID/src/utils/strings.js
+++ b/BrightID/src/utils/strings.js
@@ -1,0 +1,12 @@
+// @flow
+
+/**
+ * Removes the spaces, the accents and converts to lower case.
+ * https://stackoverflow.com/a/37511463
+ */
+export const toSearchString = (str: string) => {
+  return str
+    .replace(/\s/g, '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+};


### PR DESCRIPTION
As requested in issue #519 , this makes searches accent insensitive.
Before :
- Connections searches were case and space insensitive.
- Groups and Group Member searches were case insensitive.

With this PR : All types of search (connection, group, group member) are case, space and accent insensitive.

On the performance side, it is adding extra string RegExp execution on-top of what was done before. 
Note that on the Connections page those RegExp are executed regardless of if there is a search ongoing or not (as opposed to the Groups page), so there is an easy optimization possible there if you are OK with it. 