### PR TITLE
[f/495] Vibrate on confirm screen

### DIFF
--- a/BrightID/src/components/PendingConnectionsScreens/MyCodeScreen.js
+++ b/BrightID/src/components/PendingConnectionsScreens/MyCodeScreen.js
@@ -11,6 +11,7 @@ import {
   StatusBar,
   InteractionManager,
   TouchableWithoutFeedback,
+  Vibration,
 } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { SvgXml } from 'react-native-svg';
@@ -122,13 +123,13 @@ export const MyCodeScreen = () => {
     ) {
       if (displayChannelType === channel_types.SINGLE) {
         // navigate immediately to pending connections
-        navigation.navigate('PendingConnections');
+        vibrateAndDisplayPendingConnections();
         // close channel to prevent navigation loop
         dispatch(closeChannel({ channelId: myChannel?.id, background: true }));
       } else if (displayChannelType === channel_types.GROUP) {
         // navigation.navigate('GroupQr', { channel: myChannel });
         timer = setTimeout(() => {
-          navigation.navigate('PendingConnections');
+          vibrateAndDisplayPendingConnections();
         }, PENDING_GROUP_TIMEOUT);
       }
     }
@@ -227,6 +228,11 @@ export const MyCodeScreen = () => {
       'Group code',
       'This QR code is designed for many people to connect simultaneously.',
     );
+  };
+
+  const vibrateAndDisplayPendingConnections = () => {
+    Vibration.vibrate();
+    navigation.navigate('PendingConnections');
   };
 
   return (


### PR DESCRIPTION
Related to issue #495 

On "Show my QR Code" screen, vibrates the device when the "Pending Connections" screen shows up following incoming connections.
- For single-use code, immediately after the other user scans the code, at the same time the "Pending Connections" screen is displayed.
- For group code, after a delay (currently 45 seconds ), at the same time the "Pending Connections" screen is displayed.