### PR TITLE
Stop polling for profiles when expected number of profiles is found

### DIFF
--- a/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
@@ -7,6 +7,7 @@ import {
   setMyChannel,
   updateChannel,
   selectAllChannelIds,
+  channel_types,
 } from '@/components/PendingConnectionsScreens/channelSlice';
 import { retrieveImage } from '@/utils/filesystem';
 import { encryptData } from '@/utils/cryptoHelper';
@@ -203,6 +204,23 @@ export const fetchChannelProfiles = createAsyncThunk(
           }),
         );
       }
+    }
+    // can we stop polling?
+    let expectedProfiles;
+    switch (channel.type) {
+      case channel_types.SINGLE:
+        expectedProfiles = 2; // my profile and peer profile
+        break;
+      case channel_types.GROUP:
+      default:
+        expectedProfiles = CHANNEL_CONNECTION_LIMIT;
+        break;
+    }
+    if (profileIds.length >= expectedProfiles) {
+      console.log(
+        `Got expected number of profiles (${expectedProfiles}) for channel ${channel.id}`,
+      );
+      dispatch(unsubscribeFromConnectionRequests(channel.id));
     }
   },
 );


### PR DESCRIPTION
Currently we keep polling for profiles until a channel gets closed, even if no more profiles are expected.
This change immediately stops polling when the expected number of profiles (depending on channel type) is found.
This should help reduce data usage and system load both on client side and profile server.