### PR TITLE
Reporting

### DIFF
--- a/BrightID/flow-typed/myLibDef.js
+++ b/BrightID/flow-typed/myLibDef.js
@@ -188,6 +188,7 @@ declare type PendingConnection = {
   notificationToken?: string,
   secretKey?: string,
   score?: number,
+  requestProof?: string,
 };
 
 declare type RecoveryData = {

--- a/BrightID/src/api/brightId.js
+++ b/BrightID/src/api/brightId.js
@@ -72,6 +72,7 @@ class NodeApi {
     level: string,
     reportReason?: string,
     timestamp: number,
+    requestProof?: string,
     fakeUser?: FakeUser,
   ) {
     let secretKey;
@@ -93,6 +94,9 @@ class NodeApi {
     };
     if (reportReason) {
       op.reportReason = reportReason;
+    }
+    if (requestProof) {
+      op.requestProof = requestProof;
     }
 
     const message = stringify(op);

--- a/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
@@ -106,11 +106,6 @@ export const joinChannel = (channel: Channel) => async (
     // we need channel to exist prior to uploadingProfileToChannel
     await dispatch(addChannel(channel));
 
-    if (channel.channelType === channel_types.GROUP) {
-      // upload my profile to channel here only for n:n channels
-      // for 1:1 channels, joiner upload profile after accepting connection
-      await dispatch(encryptAndUploadProfileToChannel(channel.id));
-    }
     // start polling for profiles
     dispatch(subscribeToConnectionRequests(channel.id));
   } catch (e) {

--- a/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/channelThunks.js
@@ -106,8 +106,11 @@ export const joinChannel = (channel: Channel) => async (
     // we need channel to exist prior to uploadingProfileToChannel
     await dispatch(addChannel(channel));
 
-    // upload my profile to channel
-    await dispatch(encryptAndUploadProfileToChannel(channel.id));
+    if (channel.channelType === channel_types.GROUP) {
+      // upload my profile to channel here only for n:n channels
+      // for 1:1 channels, joiner upload profile after accepting connection
+      await dispatch(encryptAndUploadProfileToChannel(channel.id));
+    }
     // start polling for profiles
     dispatch(subscribeToConnectionRequests(channel.id));
   } catch (e) {

--- a/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
@@ -47,15 +47,15 @@ export const confirmPendingConnectionThunk = (
     user: { id: brightId, backupCompleted },
   } = getState();
 
-  let connectionTimestamp = Date.now();
+  let connectionTimestamp = connection.profileTimestamp;
   let flagReason;
-
   await api.addConnection(
     brightId,
     connection.brightId,
     level,
     flagReason,
     connectionTimestamp,
+    connection.requestProof
   );
 
   if (__DEV__) {
@@ -67,6 +67,7 @@ export const confirmPendingConnectionThunk = (
         level,
         flagReason,
         connectionTimestamp,
+        connection.requestProof,
         {
           id: connection.brightId,
           secretKey: connection.secretKey,

--- a/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
@@ -13,7 +13,10 @@ import {
   selectPendingConnectionById,
   updatePendingConnection,
 } from '@/components/PendingConnectionsScreens/pendingConnectionSlice';
-import { leaveChannel } from '@/components/PendingConnectionsScreens/actions/channelThunks';
+import {
+  encryptAndUploadProfileToChannel,
+  leaveChannel
+} from '@/components/PendingConnectionsScreens/actions/channelThunks';
 
 export const confirmPendingConnectionThunk = (
   id: string,
@@ -74,6 +77,7 @@ export const confirmPendingConnectionThunk = (
         },
       );
     }
+
   }
 
   // save connection photo
@@ -99,6 +103,12 @@ export const confirmPendingConnectionThunk = (
   dispatch(confirmPendingConnection(connection.id));
 
   if (channel.type === channel_types.SINGLE) {
+    if (channel.initiatorProfileId !== channel.myProfileId &&
+      level != 'suspicious' && level != 'reported') {
+      // for 1:1 channel upload profile of joiner to channel for creator
+      // only after accepting the connection with creator
+      await dispatch(encryptAndUploadProfileToChannel(channel.id));
+    }
     // Connection is established, so the 1:1 channel can be left
     dispatch(leaveChannel(channel.id));
   }

--- a/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
+++ b/BrightID/src/components/PendingConnectionsScreens/actions/pendingConnectionThunks.js
@@ -101,14 +101,22 @@ export const confirmPendingConnectionThunk = (
 
   dispatch(addConnection(connectionData));
   dispatch(confirmPendingConnection(connection.id));
+  if (
+    // the user is not creator of channel
+    channel.initiatorProfileId !== channel.myProfileId &&
+    // and the user accepted the connection
+    level != 'suspicious' && level != 'reported' && (
+      // and the channel is 1:1
+      channel.type === channel_types.SINGLE ||
+      // or the user is accepting connection with the initiator
+      channel.initiatorProfileId === connection.id
+    )) {
+    // upload profile of joiner to channel
+    // only after accepting the connection with creator
+    await dispatch(encryptAndUploadProfileToChannel(channel.id));
+  }
 
   if (channel.type === channel_types.SINGLE) {
-    if (channel.initiatorProfileId !== channel.myProfileId &&
-      level != 'suspicious' && level != 'reported') {
-      // for 1:1 channel upload profile of joiner to channel for creator
-      // only after accepting the connection with creator
-      await dispatch(encryptAndUploadProfileToChannel(channel.id));
-    }
     // Connection is established, so the 1:1 channel can be left
     dispatch(leaveChannel(channel.id));
   }

--- a/BrightID/src/components/PendingConnectionsScreens/pendingConnectionSlice.js
+++ b/BrightID/src/components/PendingConnectionsScreens/pendingConnectionSlice.js
@@ -169,6 +169,7 @@ const pendingConnectionsSlice = createSlice({
         flagged,
         notificationToken,
         verifications,
+        requestProof,
       } = action.payload;
 
       const changes = {
@@ -188,6 +189,7 @@ const pendingConnectionsSlice = createSlice({
         flagged,
         notificationToken,
         verifications,
+        requestProof,
       };
 
       // add secret key if dev

--- a/BrightID/src/utils/channels.js
+++ b/BrightID/src/utils/channels.js
@@ -23,7 +23,7 @@ export const generateChannelData = async (
   const ttl = CHANNEL_TTL;
   const myProfileId = await createRandomId();
   const type = channelType;
-  const initiatorProfileId = '';
+  const initiatorProfileId = myProfileId;
   const state = channel_states.OPEN;
   const channelApi = new ChannelAPI(`http://${ipAddress}/profile`);
 


### PR DESCRIPTION
- add requestProof to the connection data that requester share initially to channel to enable scanners prove the request was made by the requester when they want to report
- do not share the scanners info to the channel before they accept the connection to ensure the users profile will not be shared with attackers