### PR TITLE
Remove versionNameSuffix from Android Staging build

### DIFF
--- a/BrightID/android/app/build.gradle
+++ b/BrightID/android/app/build.gradle
@@ -219,7 +219,6 @@ android {
         }
         staging {
             applicationIdSuffix ".staging"
-            versionNameSuffix '-STAGING'
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.staging


### PR DESCRIPTION
Required to make codePush updates targeting a version range possible.