### PR TITLE
Fix expiring channel

### DIFF
--- a/BrightID/e2e/i18n_for_tests.js
+++ b/BrightID/e2e/i18n_for_tests.js
@@ -1,8 +1,8 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import moment from 'moment';
 
-import * as englishTranslation from '../translations/english.json';
-import * as frenchTranslation from '../translations/french.json';
+import * as englishTranslation from '../locales/en/translation.json';
 
 /*
   This is mostly a copy of /i18n.js, but without dependency on react-native-localize. This way it is possible
@@ -13,9 +13,6 @@ const translations = {
   en: {
     translation: englishTranslation,
   },
-  fr: {
-    translation: frenchTranslation,
-  },
 };
 
 const defaultLanguage = {
@@ -25,14 +22,21 @@ const defaultLanguage = {
 
 const { languageTag } = defaultLanguage;
 
-i18n.use(initReactI18next).init({
-  resources: translations,
-  lng: languageTag,
-  fallbackLng: 'en',
-  keySeparator: false,
-  interpolation: {
-    escapeValue: false,
-  },
-});
+/**
+ * Moment will use detected language throughout the app.
+ */
+moment.locale(languageTag);
+
+i18n
+  .use(initReactI18next) // bind react-i18next to the instance
+  .init({
+    resources: translations,
+    lng: languageTag,
+    fallbackLng: 'en',
+    returnEmptyString: false,
+    interpolation: {
+      escapeValue: false,
+    },
+  });
 
 export default i18n;

--- a/BrightID/e2e/onboarding.spec.js
+++ b/BrightID/e2e/onboarding.spec.js
@@ -1,7 +1,11 @@
 /* global element:false, by:false */
 
+import { acceptEula } from './testUtils';
+
 describe('Onboarding', () => {
   it('should have onboarding carousel screen', async () => {
+    // accept EULA
+    await acceptEula();
     // First page should be there at start
     await expect(element(by.id('brightIdOnboard'))).toBeVisible();
     // Swipe left to show second page

--- a/BrightID/e2e/testUtils.js
+++ b/BrightID/e2e/testUtils.js
@@ -5,7 +5,18 @@ import i18next from 'i18next';
 
 const testUserName = 'Vincent Vega';
 
+/*
+Accept EULA and proceed to Onboarding screen
+ */
+const acceptEula = async () => {
+  await expect(element(by.id('EulaScreen'))).toBeVisible();
+  await expect(element(by.id('acceptEulaBtn'))).toExist();
+  await element(by.id('acceptEulaBtn')).tap();
+  await expect(element(by.id('brightIdOnboard'))).toBeVisible();
+};
+
 const createBrightID = async (name: string = testUserName) => {
+  await acceptEula();
   await element(by.id('getStartedBtn')).tap();
   await element(by.id('editName')).tap();
   await element(by.id('editName')).replaceText(name);
@@ -251,6 +262,7 @@ const reconnect = async (connectionIndex: number, changeProfile: boolean) => {
 
 export {
   testUserName,
+  acceptEula,
   createBrightID,
   createFakeConnection,
   expectHomescreen,

--- a/BrightID/src/components/OnboardingScreens/Eula.js
+++ b/BrightID/src/components/OnboardingScreens/Eula.js
@@ -37,12 +37,20 @@ export const Eula = ({ navigation }) => {
         backgroundColor={WHITE}
         animated={true}
       />
-      <View style={styles.container} behavior="padding">
+      <View testID="EulaScreen" style={styles.container} behavior="padding">
         <View style={styles.confirmationButtons}>
-          <TouchableOpacity style={styles.rejectButton} onPress={handleReject}>
+          <TouchableOpacity
+            testID="rejectEulaBtn"
+            style={styles.rejectButton}
+            onPress={handleReject}
+          >
             <Text style={styles.rejectButtonText}>Reject</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.acceptButton} onPress={handleAccept}>
+          <TouchableOpacity
+            testID="acceptEulaBtn"
+            style={styles.acceptButton}
+            onPress={handleAccept}
+          >
             <Text style={styles.acceptButtonText}>Accept</Text>
           </TouchableOpacity>
         </View>

--- a/BrightID/src/components/PendingConnectionsScreens/PreviewConnectionController.js
+++ b/BrightID/src/components/PendingConnectionsScreens/PreviewConnectionController.js
@@ -25,16 +25,15 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
   const { pendingConnectionId, ratingHandler, index } = props;
   const dispatch = useDispatch();
 
-  const pendingConnection = useSelector(
-    (state) =>
-      selectPendingConnectionById(state, pendingConnectionId) ?? {
-        state: pendingConnection_states.EXPIRED,
-      },
-    (a, b) => a?.state === b?.state,
+  const pendingConnection = useSelector((state) =>
+    selectPendingConnectionById(state, pendingConnectionId),
   );
 
   const existingConnection = useSelector((state) => {
-    if (pendingConnection.state === pendingConnection_states.UNCONFIRMED) {
+    if (
+      pendingConnection &&
+      pendingConnection.state === pendingConnection_states.UNCONFIRMED
+    ) {
       return state.connections.connections.find(
         (conn) => conn.id === pendingConnection.brightId,
       );
@@ -44,6 +43,12 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
   });
 
   const navigation = useNavigation();
+
+  if (!pendingConnection) {
+    // pending connection has vanished. Most likely channel expired.
+    // Just return null, parent components will take care of moving to a different screen.
+    return null;
+  }
 
   const setLevelHandler = (level: ConnectionLevel) => {
     ratingHandler(pendingConnection.id, level, index);


### PR DESCRIPTION
Fixes really stupid code where I was returning a dummy pendingConnection object when the pendingConnection was not existing. This resulted in the app crashing whenever a channel expired while the UI showing the pending connection previews.

Also included detox updates to handle new EULA screen and changed location of translation files.