### PR TITLE
Remove qrcode fallback

### DIFF
--- a/BrightID/flow-typed/myLibDef.js
+++ b/BrightID/flow-typed/myLibDef.js
@@ -71,7 +71,6 @@ declare type Channel = {
   id: string,
   initiatorProfileId: string,
   myProfileId: string,
-  ipAddress?: string,
   aesKey: string,
   timestamp: number,
   ttl: number,

--- a/BrightID/src/api/brightId.js
+++ b/BrightID/src/api/brightId.js
@@ -459,12 +459,6 @@ class NodeApi {
     NodeApi.throwOnError(res);
     return res.data.data.apps;
   }
-
-  async ip(): string {
-    let res = await this.api.get('/ip');
-    NodeApi.throwOnError(res);
-    return res.data.data.ip;
-  }
 }
 
 const brightId = new NodeApi();

--- a/BrightID/src/api/channelService.js
+++ b/BrightID/src/api/channelService.js
@@ -6,13 +6,13 @@
     Operations:
 
     - Upload data with unique ID to channel
-        -> POST http://${ipAddress}/profile/upload/${channelID}
+        -> POST /profile/upload/${channelID}
     - Get list of data IDs in channel
-        -> GET http://${ipAddress}/profile/list/${channelID}
+        -> GET /profile/list/${channelID}
     - Download data from channel
-        -> GET http://${ipAddress}/profile/download/${channelID}/${dataID}
+        -> GET /profile/download/${channelID}/${dataID}
 
-    We need to support multiple different IPAddresses (hosts?), so
+    We need to support multiple different hosts, so
     we can not use a global API instance. Instead it needs to be created per channel.
  */
 import { create, ApiSauceInstance } from 'apisauce';

--- a/BrightID/src/components/PendingConnectionsScreens/QrCode.js
+++ b/BrightID/src/components/PendingConnectionsScreens/QrCode.js
@@ -26,8 +26,7 @@ import {
   channel_types,
   closeChannel,
 } from '@/components/PendingConnectionsScreens/channelSlice';
-import { buildChannelQrUrl, encodeChannelQrString } from '@/utils/channels';
-import { CHANNEL_SWITCH_TIMESTAMP } from '../../utils/constants';
+import { buildChannelQrUrl } from '@/utils/channels';
 
 /**
  * My Code screen of BrightID
@@ -84,11 +83,7 @@ export const QrCode = ({ channel }) => {
   // create QRCode from channel data
   useEffect(() => {
     if (channel && channel.state === channel_states.OPEN) {
-      const newQrString =
-        channel.timestamp > CHANNEL_SWITCH_TIMESTAMP
-          ? buildChannelQrUrl(channel).href
-          : encodeChannelQrString(channel);
-
+      const newQrString = buildChannelQrUrl(channel).href;
       // do not re-render svg if we already have the string
       if (newQrString !== qrString) {
         console.log(

--- a/BrightID/src/components/PendingConnectionsScreens/ScanCodeScreen.js
+++ b/BrightID/src/components/PendingConnectionsScreens/ScanCodeScreen.js
@@ -28,7 +28,7 @@ import {
   closeChannel,
 } from '@/components/PendingConnectionsScreens/channelSlice';
 import { selectAllUnconfirmedConnectionsByChannelIds } from '@/components/PendingConnectionsScreens/pendingConnectionSlice';
-import { decodeChannelQrString, parseChannelQrURL } from '@/utils/channels';
+import { parseChannelQrURL } from '@/utils/channels';
 import { joinChannel } from '@/components/PendingConnectionsScreens/actions/channelThunks';
 import { setActiveNotification } from '@/actions';
 
@@ -123,26 +123,11 @@ export const ScanCodeScreen = () => {
           console.log(`handleQrData: calling Linking.openURL() with ${qrData}`);
           await Linking.openURL(qrData);
         } else if (validQrString(qrData)) {
-          let channel;
-          try {
-            const channelURL = new URL(qrData);
-            console.log(
-              `handleQrData: valid channelURL, joining channel at ${channelURL.href}`,
-            );
-            channel = await parseChannelQrURL(channelURL);
-          } catch (e) {
-            if (e instanceof TypeError) {
-              console.log(
-                `Failed to parse url, trying fallback to old format...`,
-              );
-              channel = await decodeChannelQrString(qrData);
-              console.log(
-                `handleQrData: valid qrdata, joining channel ${channel.id}`,
-              );
-            } else {
-              throw e;
-            }
-          }
+          const channelURL = new URL(qrData);
+          console.log(
+            `handleQrData: valid channelURL, joining channel at ${channelURL.href}`,
+          );
+          const channel = await parseChannelQrURL(channelURL);
           setChannel(channel);
           await dispatch(joinChannel(channel));
         } else {

--- a/BrightID/src/components/PendingConnectionsScreens/channelSlice.js
+++ b/BrightID/src/components/PendingConnectionsScreens/channelSlice.js
@@ -13,7 +13,6 @@ import {
   - 'api': instance of ChannelAPI for this channel
   - 'id': unique identifier
   - 'initiatorProfileId': profileId of channel initiator
-  - 'ipAddress': IP of profile service
   - 'myProfileId': my profileId in this channel
   - 'pollTimerId: IntervalId of timer polling for incoming connection requests from this channel
   - 'state': state of channel - see channel_states below
@@ -21,6 +20,7 @@ import {
   - 'ttl': time to live of channel (seconds)
   - 'type': group or 1:1 connection - see channel_types below
   - 'timeoutId: Id of timer to expire channel once ttl is reached
+  - 'url': url of channel
 
   The app could hold multiple channels at the same time. E.g. if i scan multiple QRCodes
   in a larger group session.

--- a/BrightID/src/components/Recovery/thunks/channelThunks.js
+++ b/BrightID/src/components/Recovery/thunks/channelThunks.js
@@ -30,10 +30,9 @@ export const createChannel = () => async (
       timestamp: recoveryData.timestamp,
     };
 
-    const ip = await api.ip();
-    const url = `http://${ip}/profile`;
+    const url = new URL(`${api.baseUrl}/profile`);
 
-    const channelApi = new ChannelAPI(url);
+    const channelApi = new ChannelAPI(url.href);
     const channelId = hash(recoveryData.aesKey);
 
     dispatch(setChannel({ channelId, url }));
@@ -105,7 +104,7 @@ export const checkChannel = () => async (
     return;
   }
 
-  const channelApi = new ChannelAPI(url);
+  const channelApi = new ChannelAPI(url.href);
   const dataIds = await channelApi.list(channelId);
 
   if (recoveryId) {

--- a/BrightID/src/components/Recovery/thunks/recovery.test.js
+++ b/BrightID/src/components/Recovery/thunks/recovery.test.js
@@ -68,7 +68,7 @@ describe('Test recovery data', () => {
       type: 'recoveryData/setChannel',
       payload: {
         channelId: expect.any(String),
-        url: expect.stringContaining('http://'),
+        url: expect.any(URL),
       },
     });
 
@@ -94,7 +94,7 @@ describe('Test recovery data', () => {
       // update timeout for this test
       jest.setTimeout(10000);
       const { aesKey } = recoveryData;
-      const channelApi = new ChannelAPI(recoveryData.channel.url);
+      const channelApi = new ChannelAPI(recoveryData.channel.url.href);
 
       const conn = {
         id: recoveryId,
@@ -119,7 +119,7 @@ describe('Test recovery data', () => {
       // update timeout for this test
       jest.setTimeout(10000);
       const { aesKey } = recoveryData;
-      const channelApi = new ChannelAPI(recoveryData.channel.url);
+      const channelApi = new ChannelAPI(recoveryData.channel.url.href);
 
       let { publicKey, secretKey } = await nacl.sign.keyPair();
       let b64PubKey = uInt8ArrayToB64(publicKey);

--- a/BrightID/src/utils/channels.js
+++ b/BrightID/src/utils/channels.js
@@ -1,15 +1,11 @@
 // @flow
-import { b64ToUint8Array, b64ToUrlSafeB64, randomKey } from '@/utils/encoding';
+import { b64ToUrlSafeB64, randomKey } from '@/utils/encoding';
 import {
   CHANNEL_TTL,
   CHANNEL_INFO_VERSION,
   CHANNEL_INFO_NAME,
 } from '@/utils/constants';
-import { Buffer } from 'buffer';
-import {
-  channel_states,
-  channel_types,
-} from '@/components/PendingConnectionsScreens/channelSlice';
+import { channel_states } from '@/components/PendingConnectionsScreens/channelSlice';
 import ChannelAPI from '@/api/channelService';
 import i18next from 'i18next';
 
@@ -21,7 +17,6 @@ export const createRandomId = async (size: number = 9) => {
 export const generateChannelData = async (
   channelType: ChannelType,
   url: URL,
-  ipAddress?: string,
 ): Promise<Channel> => {
   const aesKey = await randomKey(16);
   const id = await createRandomId();
@@ -38,7 +33,6 @@ export const generateChannelData = async (
     api: channelApi,
     id,
     initiatorProfileId,
-    ipAddress,
     myProfileId,
     state,
     timestamp,
@@ -110,79 +104,6 @@ export const parseChannelQrURL = async (url: URL) => {
     timestamp: channelInfo.timestamp,
     ttl: channelInfo.ttl,
     type: channelInfo.type,
-    url,
-  };
-  return channel;
-};
-
-export const encodeChannelQrString = (channel: Channel) => {
-  const { aesKey, id, ipAddress, myProfileId, timestamp, ttl, type } = channel;
-  if (!ipAddress) {
-    throw Error(`Cant create old format channelQRString - ipAddress missing`);
-  }
-  const b64Ip = Buffer.from(
-    ipAddress.split('.').map((octet) => parseInt(octet, 10)),
-  )
-    .toString('base64')
-    .substring(0, 6);
-  let intType;
-  switch (type) {
-    case channel_types.GROUP:
-      intType = 0;
-      break;
-    case channel_types.SINGLE:
-      intType = 1;
-      break;
-    default:
-      throw new Error(`Unhandled channel type ${type}`);
-  }
-  return encodeURIComponent(
-    `${aesKey}${id}${myProfileId}${b64Ip}${intType}${timestamp}${ttl}`,
-  );
-};
-
-export const decodeChannelQrString = async (qrString: string) => {
-  const decodedQR = decodeURIComponent(qrString);
-  const aesKey = decodedQR.substr(0, 24);
-  const id = decodedQR.substr(24, 12);
-  const initiatorProfileId = decodedQR.substr(36, 12);
-  const b64ip = `${decodedQR.substr(48, 6)}==`;
-  const ipAddress = b64ToUint8Array(b64ip).join('.');
-  const intType = parseInt(decodedQR.substr(54, 1), 10);
-  // 13 digits for timestamp will be safe until Saturday, 20. November 2286 17:46:39.999
-  const timestamp = parseInt(decodedQR.substr(55, 13), 10);
-  // ttl has unknown length, so just parse everything till the end
-  const ttl = parseInt(decodedQR.substr(68), 10);
-
-  // add local channel data that is not part of qrstring
-  const myProfileId = await createRandomId();
-  const state = channel_states.OPEN;
-  const url = new URL(`http://${ipAddress}/profile`);
-  const channelApi = new ChannelAPI(url.href);
-
-  // convert intType to ChannelType
-  let type;
-  switch (intType) {
-    case 0:
-      type = channel_types.GROUP;
-      break;
-    case 1:
-      type = channel_types.SINGLE;
-      break;
-    default:
-      throw new Error(`Unhandled channel intType ${intType}`);
-  }
-
-  const channel: Channel = {
-    aesKey,
-    api: channelApi,
-    id,
-    initiatorProfileId,
-    myProfileId,
-    state,
-    timestamp,
-    ttl,
-    type,
     url,
   };
   return channel;

--- a/BrightID/src/utils/channels.js
+++ b/BrightID/src/utils/channels.js
@@ -26,7 +26,7 @@ export const generateChannelData = async (
   const type = channelType;
   const initiatorProfileId = '';
   const state = channel_states.OPEN;
-  const channelApi = new ChannelAPI(`${url.href}`);
+  const channelApi = new ChannelAPI(url.href);
 
   return {
     aesKey,

--- a/BrightID/src/utils/channels.test.js
+++ b/BrightID/src/utils/channels.test.js
@@ -1,7 +1,5 @@
 import {
   generateChannelData,
-  decodeChannelQrString,
-  encodeChannelQrString,
   createChannelInfo,
   buildChannelQrUrl,
 } from '@/utils/channels';

--- a/BrightID/src/utils/constants.js
+++ b/BrightID/src/utils/constants.js
@@ -16,11 +16,7 @@ export const TIME_FUDGE = 60 * 60 * 1000;
 export const PROFILE_VERSION = 1;
 export const CHANNEL_INFO_NAME = 'channelInfo.json';
 export const CHANNEL_INFO_VERSION = 1;
-// Thursday, January 21 2021 00:00:00
-export const CHANNEL_SWITCH_TIMESTAMP = 1611187200 * 1000;
-// Monday, January 11 2021 00:00:00
-// export const CHANNEL_SWITCH_TIMESTAMP = 1610323200 * 1000;
-//** ** THEME CONSTANTS  *** */
+//* * ** THEME CONSTANTS  *** */
 export const ORANGE = '#ED7A5D';
 export const LIGHTBLUE = '#4A90E2';
 export const DARK_ORANGE = '#B64B32';


### PR DESCRIPTION
Remove the existing fallback logic for old-style qrcodes.
Also remove the `ip()` method from node API as it is not used anymore.