### PR TITLE
Include profile server url in recovery qrcode

### DIFF
--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionScreen.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, Text, View, FlatList } from 'react-native';
 import Spinner from 'react-native-spinkit';
 import { useSelector } from '@/store';
 import { useTranslation } from 'react-i18next';
-import { useRoute, RouteProp } from '@react-navigation/native';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { connectionsSelector } from '@/utils/connectionsSelector';
@@ -19,25 +18,15 @@ const getItemLayout = (data, index) => ({
   index,
 });
 
-type RecoveringConnectionRoute = RouteProp<
-  { RecoveringConnection: { aesKey: string } },
-  'RecoveringConnection'
->;
-
 const RecoveringConnectionScreen = () => {
   const connections = useSelector(connectionsSelector);
   const { t } = useTranslation();
-  const route = useRoute<RecoveringConnectionRoute>();
   const [uploadingData, setUploadingData] = useState(false);
 
   const renderConnection = ({ item, index }) => {
     item.index = index;
     return (
-      <RecoveringConnectionCard
-        {...item}
-        aesKey={route.params?.aesKey}
-        setUploadingData={setUploadingData}
-      />
+      <RecoveringConnectionCard {...item} setUploadingData={setUploadingData} />
     );
   };
 

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
@@ -142,12 +142,19 @@ const RecoveryCodeScreen = () => {
     const universalLink = `https://app.brightid.org/connection-code/${encodeURIComponent(
       qrUrl.href,
     )}`;
-    const clipboardMsg = universalLink; // TODO Copy plain url if in DEV mode
-    const alertMsg = `Share this link with your recovery connections.`;
+    const clipboardMsg = __DEV__
+      ? universalLink
+      : t('recovery.alert.clipboardmessage', {
+          defaultValue: 'Help me recover my BrightID: {{link}}',
+          link: universalLink,
+        });
 
     Alert.alert(
-      t('qrcode.alert.text.universalLink'),
-      alertMsg,
+      t('recovery.alert.title', 'Recovery link'),
+      t(
+        'recovery.alert.text',
+        'Share this link with your recovery connections.',
+      ),
       [
         {
           text: t('common.button.copy'),

--- a/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { useDispatch, useSelector } from '@/store';
 import { useTranslation } from 'react-i18next';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import {
   connectionsSelector,
   recoveryConnectionsSelector,
@@ -53,9 +53,10 @@ const TrustedConnectionsScreen = () => {
     connection_levels.ALREADY_KNOWN,
     connection_levels.RECOVERY,
   );
-  const knownConnections = connections.filter((conn) =>
-    knownLevels.includes(conn.incomingLevel) ||
-    conn.level == connection_levels.RECOVERY,
+  const knownConnections = connections.filter(
+    (conn) =>
+      knownLevels.includes(conn.incomingLevel) ||
+      conn.level === connection_levels.RECOVERY,
   );
 
   const toggleSelection = (id) => {

--- a/BrightID/src/components/Onboarding/RecoveryFlow/recoveryDataSlice.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/recoveryDataSlice.ts
@@ -16,7 +16,6 @@ export const initialState: RecoveryData = {
   timestamp: 0,
   sigs: {},
   qrcode: '',
-  channelhref: '',
   recoveredConnections: 0,
   recoveredGroups: 0,
   channel: {
@@ -52,7 +51,13 @@ const recoveryData = createSlice({
       state.timestamp = Date.now();
       state.sigs = {};
     },
-    setChannel(state, action: PayloadAction<{ channelId: string; url: URL }>) {
+    setAesKey(state, action: PayloadAction<string>) {
+      state.aesKey = action.payload;
+    },
+    setRecoveryChannel(
+      state,
+      action: PayloadAction<{ channelId: string; url: URL }>,
+    ) {
       const { channelId, url } = action.payload;
       state.channel.channelId = channelId;
       state.channel.url = url;
@@ -116,7 +121,8 @@ export const {
   init,
   increaseRecoveredConnections,
   increaseRecoveredGroups,
-  setChannel,
+  setAesKey,
+  setRecoveryChannel,
   setSig,
   updateNamePhoto,
   resetChannelExpiration,

--- a/BrightID/src/components/Onboarding/RecoveryFlow/recoveryDataSlice.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/recoveryDataSlice.ts
@@ -16,6 +16,7 @@ export const initialState: RecoveryData = {
   timestamp: 0,
   sigs: {},
   qrcode: '',
+  channelhref: '',
   recoveredConnections: 0,
   recoveredGroups: 0,
   channel: {
@@ -50,7 +51,6 @@ const recoveryData = createSlice({
       state.recoveredGroups = 0;
       state.timestamp = Date.now();
       state.sigs = {};
-      state.qrcode = encodeURIComponent(`Recovery2_${aesKey}`);
     },
     setChannel(state, action: PayloadAction<{ channelId: string; url: URL }>) {
       const { channelId, url } = action.payload;

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
@@ -8,8 +8,10 @@ import {
   downloadSigs,
   downloadNamePhoto,
 } from './channelDownloadThunks';
-import { setupRecovery } from './recoveryThunks';
-import { resetChannelExpiration, setChannel } from '../recoveryDataSlice';
+import {
+  resetChannelExpiration,
+  setRecoveryChannel,
+} from '../recoveryDataSlice';
 
 // CONSTANTS
 
@@ -28,7 +30,7 @@ export const createChannel = () => async (
     const channelApi = new ChannelAPI(url.href);
     const channelId = hash(recoveryData.aesKey);
     console.log(`created channel ${channelId} for recovery data`);
-    dispatch(setChannel({ channelId, url }));
+    dispatch(setRecoveryChannel({ channelId, url }));
     await uploadRecoveryData(recoveryData, channelApi);
     console.log(`Finished uploading recovery data to channel ${channelId}`);
   } catch (e) {

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
@@ -27,12 +27,10 @@ export const createChannel = () => async (
     const url = new URL(`${api.baseUrl}/profile`);
     const channelApi = new ChannelAPI(url.href);
     const channelId = hash(recoveryData.aesKey);
-
+    console.log(`created channel ${channelId} for recovery data`);
     dispatch(setChannel({ channelId, url }));
-
     await uploadRecoveryData(recoveryData, channelApi);
-
-    console.log(`creating channel for recovery data: ${channelId}`);
+    console.log(`Finished uploading recovery data to channel ${channelId}`);
   } catch (e) {
     const msg = 'Profile data already exists in channel';
     if (!e.message.startsWith(msg)) {
@@ -62,11 +60,6 @@ let channelIntervalId: IntervalId;
 let checkInProgress = false;
 
 export const pollChannel = () => async (dispatch: dispatch) => {
-  // creates publicKey, secretKey, aesKey for user
-  await dispatch(setupRecovery());
-  // create channel for recovery sigs
-  await dispatch(createChannel());
-
   clearInterval(channelIntervalId);
 
   channelIntervalId = setInterval(() => {

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test.ts
@@ -53,7 +53,6 @@ describe('Test recovery data', () => {
       secretKey: action.payload.secretKey,
       aesKey: action.payload.aesKey,
       timestamp: Date.now(),
-      qrcode: encodeURIComponent(`Recovery2_${action.payload.aesKey}`),
     });
   });
 
@@ -63,7 +62,7 @@ describe('Test recovery data', () => {
     const store = mockStore({ recoveryData });
 
     const expectedAction = expect.objectContaining({
-      type: 'recoveryData/setChannel',
+      type: 'recoveryData/setRecoveryChannel',
       payload: {
         channelId: expect.any(String),
         url: expect.any(URL),

--- a/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
+++ b/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
@@ -123,12 +123,33 @@ export const ScanCodeScreen = () => {
           await Linking.openURL(qrData);
         } else if (validQrString(qrData)) {
           const channelURL = new URL(qrData);
-          console.log(
-            `handleQrData: valid channelURL, joining channel at ${channelURL.href}`,
-          );
-          const channel = await parseChannelQrURL(channelURL);
-          setChannel(channel);
-          await dispatch(joinChannel(channel));
+
+          // Pop type parameter from url
+          const urlType = channelURL.searchParams.get('t');
+          if (urlType) channelURL.searchParams.delete('t');
+
+          switch (urlType) {
+            // TODO: Enum!
+            case '1': {
+              console.log(
+                `handleQrData: Got recovery channel at ${channelURL.href}`,
+              );
+              const aesKey = channelURL.searchParams.get('aes');
+              navigation.navigate('RecoveringConnection', { aesKey });
+              break;
+            }
+            case '2': // TODO: Enum!
+            case undefined:
+            default: {
+              console.log(
+                `handleQrData: Got connection channel at ${channelURL.href}`,
+              );
+              const channel = await parseChannelQrURL(channelURL);
+              setChannel(channel);
+              await dispatch(joinChannel(channel));
+              break;
+            }
+          }
         } else {
           throw Error(`Can not parse QRData ${qrData}`);
         }

--- a/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
+++ b/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
@@ -31,7 +31,13 @@ import { joinChannel } from '@/components/PendingConnections/actions/channelThun
 import { setActiveNotification } from '@/actions';
 import i18next from 'i18next';
 import { BarCodeReadEvent } from 'react-native-camera';
+import { hash } from '@/utils/encoding';
+import { qrCodeURL_types } from '@/utils/constants';
 import { RNCamera } from './RNCameraProvider';
+import {
+  setAesKey,
+  setRecoveryChannel,
+} from '../Onboarding/RecoveryFlow/recoveryDataSlice';
 
 /**
  * Returns whether the string is a valid QR identifier
@@ -114,33 +120,44 @@ export const ScanCodeScreen = () => {
   useEffect(() => {
     const handleQrData = async (qrData) => {
       try {
-        if (qrData.startsWith('Recovery2_')) {
-          navigation.navigate('RecoveringConnection', {
-            aesKey: decodeURIComponent(qrData.replace('Recovery2_', '')),
-          });
-        } else if (qrData.startsWith('brightid://')) {
+        if (qrData.startsWith('brightid://')) {
           console.log(`handleQrData: calling Linking.openURL() with ${qrData}`);
           await Linking.openURL(qrData);
         } else if (validQrString(qrData)) {
           const channelURL = new URL(qrData);
 
-          // Pop type parameter from url
+          // Pop 'type' parameter from url if it is included
           const urlType = channelURL.searchParams.get('t');
           if (urlType) channelURL.searchParams.delete('t');
 
           switch (urlType) {
             // TODO: Enum!
-            case '1': {
-              console.log(
-                `handleQrData: Got recovery channel at ${channelURL.href}`,
-              );
+            case qrCodeURL_types.RECOVERY: {
+              // Pop 'aes' parameter from url
               const aesKey = channelURL.searchParams.get('aes');
-              navigation.navigate('RecoveringConnection', { aesKey });
+              channelURL.searchParams.delete('aes');
+
+              const channelId = hash(aesKey);
+              console.log(
+                `handleQrData: Got recovery channel ${channelId} at ${channelURL.href}`,
+              );
+
+              dispatch(setAesKey(aesKey));
+              dispatch(
+                setRecoveryChannel({
+                  channelId,
+                  url: channelURL,
+                }),
+              );
+              navigation.navigate('RecoveringConnection');
               break;
             }
-            case '2': // TODO: Enum!
-            case undefined:
+            case qrCodeURL_types.CONNECTION:
             default: {
+              // Currently assuming qrcodes without type parameter are connection channels created by previous app
+              // versions. Change this in one of the next releases:
+              // -> Add type parameter 't' to connection channel qrcode
+              // -> Throw an error if no/unknown type is found in qrcode
               console.log(
                 `handleQrData: Got connection channel at ${channelURL.href}`,
               );

--- a/BrightID/src/utils/constants.ts
+++ b/BrightID/src/utils/constants.ts
@@ -49,3 +49,8 @@ export const report_reasons = {
   DECEASED: 'deceased',
   OTHER: 'other',
 };
+
+export enum qrCodeURL_types {
+  CONNECTION = '1', // qrcode url is for connection channel
+  RECOVERY = '2', // qrcode url is for recovery channel
+}

--- a/BrightID/src/utils/recovery.ts
+++ b/BrightID/src/utils/recovery.ts
@@ -1,19 +1,15 @@
 import {
+  qrCodeURL_types,
   RECOVERY_COOLDOWN_DURATION,
   RECOVERY_COOLDOWN_EXEMPTION,
 } from '@/utils/constants';
 
-/**
- *
- * @param {{
- * recoveryConnections: Connection[],
- * connection?: Connection,
- * }}
- * @returns {number}
- */
 export const calculateCooldownPeriod = ({
   recoveryConnections,
   connection,
+}: {
+  recoveryConnections: Connection[];
+  connection?: Connection;
 }) => {
   // no cooldown if setting the first recovery connection
   if (recoveryConnections.length === 0) {
@@ -63,7 +59,6 @@ export const calculateCooldownPeriod = ({
 export const buildRecoveryChannelQrUrl = ({ aesKey, url }: RecoveryChannel) => {
   const qrUrl = new URL(url.href);
   qrUrl.searchParams.append('aes', aesKey);
-  // set type "recovery"
-  qrUrl.searchParams.append('t', '1'); // TODO use enum
+  qrUrl.searchParams.append('t', qrCodeURL_types.RECOVERY);
   return qrUrl;
 };

--- a/BrightID/src/utils/recovery.ts
+++ b/BrightID/src/utils/recovery.ts
@@ -1,4 +1,3 @@
-// @flow
 import {
   RECOVERY_COOLDOWN_DURATION,
   RECOVERY_COOLDOWN_EXEMPTION,
@@ -59,4 +58,12 @@ export const calculateCooldownPeriod = ({
 
   // no special case and no specific connection provided. Just return default cooldown period.
   return RECOVERY_COOLDOWN_DURATION;
+};
+
+export const buildRecoveryChannelQrUrl = ({ aesKey, url }: RecoveryChannel) => {
+  const qrUrl = new URL(url.href);
+  qrUrl.searchParams.append('aes', aesKey);
+  // set type "recovery"
+  qrUrl.searchParams.append('t', '1'); // TODO use enum
+  return qrUrl;
 };

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -204,6 +204,11 @@ declare global {
     errorMessage: string;
   };
 
+  type RecoveryChannel = {
+    aesKey: string;
+    url: URL;
+  };
+
   type SocialMediaId = keyof typeof socialMediaList;
 
   type SocialMedia = {

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -48,17 +48,6 @@ declare global {
     linkedContexts: ContextInfo[];
   };
 
-  // type AppInfo = {
-  //   id: string;
-  //   name: string;
-  //   logo: string;
-  //   context: string;
-  //   verification: string;
-  //   url: string;
-  //   unusedSponsorships: number;
-  //   assignedSponsorships: number;
-  // };
-
   type ContextInfo = {
     context: string;
     contextId: string;


### PR DESCRIPTION
QRCodes for recovery are now created similar to connection codes. So the creator of the code includes the url to the profile server for data exchange. The people scanning the code will use that url instead of default `node.brightid.org`.

Fixes #777 