### PR TITLE
Support multiple node backends

### DIFF
--- a/BrightID/e2e/apps.spec.js
+++ b/BrightID/e2e/apps.spec.js
@@ -17,7 +17,7 @@ function getRandomAddres() {
   return a;
 }
 
-const apps = [
+const apps2 = [
   {
     id: '1hive',
     name: '1Hive Honey Faucet',

--- a/BrightID/package.json
+++ b/BrightID/package.json
@@ -52,6 +52,7 @@
     "immer": "8.0.1",
     "lodash": "4.17.20",
     "moment": "2.29.1",
+    "promise.any": "^2.0.2",
     "prop-types": "15.7.2",
     "qrcode": "1.4.4",
     "ramda": "0.27.1",

--- a/BrightID/src/App.tsx
+++ b/BrightID/src/App.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/es/integration/react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer } from '@react-navigation/native';
-import { InteractionManager, Linking } from 'react-native';
+import { Linking } from 'react-native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
-import { pollOperations } from '@/utils/operations';
 import AppRoutes from './routes';
 import { store, persistor } from './store';
 import { navigationRef } from './NavigationService';
@@ -20,7 +19,6 @@ import { NotificationBanner } from './components/Helpers/NotificationBanner';
 // NOTE: BOOTSTRAP happens inside of LoadingScreen
 export const App = () => {
   // setup deep linking
-
   const linking = {
     prefixes: ['brightid://', 'https://app.brightid.org'],
     config: {
@@ -61,19 +59,6 @@ export const App = () => {
       };
     },
   };
-
-  useEffect(() => {
-    // subscribe to operations
-    const timerId = setInterval(() => {
-      InteractionManager.runAfterInteractions(() => {
-        pollOperations();
-      });
-    }, 5000);
-
-    return () => {
-      clearInterval(timerId);
-    };
-  }, []);
 
   console.log('RENDERING ENTIRE APP');
 

--- a/BrightID/src/actions/apps.ts
+++ b/BrightID/src/actions/apps.ts
@@ -1,8 +1,9 @@
-import api from '@/api/brightId';
 import { setApps } from '@/reducer/appsSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
-export const fetchApps = () => async (dispatch: dispatch) => {
+export const fetchApps = () => async (dispatch: dispatch, getState) => {
   try {
+    const api = selectNodeApi(getState());
     const apps = await api.getApps();
     dispatch(setApps(apps));
   } catch (err) {

--- a/BrightID/src/actions/apps.ts
+++ b/BrightID/src/actions/apps.ts
@@ -1,9 +1,7 @@
 import { setApps } from '@/reducer/appsSlice';
-import { selectNodeApi } from '@/reducer/settingsSlice';
 
-export const fetchApps = () => async (dispatch: dispatch, getState) => {
+export const fetchApps = (api) => async (dispatch: dispatch, getState) => {
   try {
-    const api = selectNodeApi(getState());
     const apps = await api.getApps();
     dispatch(setApps(apps));
   } catch (err) {

--- a/BrightID/src/actions/fakeContact.ts
+++ b/BrightID/src/actions/fakeContact.ts
@@ -14,8 +14,8 @@ import { names } from '@/utils/fakeNames';
 import { connectFakeUsers } from '@/utils/fakeHelper';
 import { retrieveImage } from '@/utils/filesystem';
 import { PROFILE_VERSION } from '@/utils/constants';
-import { selectNodeApi } from '@/reducer/settingsSlice';
 import { addOperation } from '@/reducer/operationsSlice';
+import { NodeApi } from '@/api/brightId';
 
 /** SELECTORS */
 
@@ -84,13 +84,12 @@ export const addFakeConnection = () => async (
   }
 };
 
-export const connectWithOtherFakeConnections = (id: string) => async (
-  dispatch: dispatch,
-  getState: getState,
-) => {
+export const connectWithOtherFakeConnections = (
+  id: string,
+  api: NodeApi,
+) => async (dispatch: dispatch, getState: getState) => {
   // get fakeUser by ID
   const fakeUser1 = selectConnectionById(getState(), id);
-  const api = selectNodeApi(getState());
 
   if (!fakeUser1) {
     console.log(`Failed to get fake connection id ${id}`);
@@ -119,13 +118,12 @@ export const connectWithOtherFakeConnections = (id: string) => async (
   }
 };
 
-export const joinAllGroups = (id: string) => async (
+export const joinAllGroups = (id: string, api: NodeApi) => async (
   dispatch: dispatch,
   getState: getState,
 ) => {
   // get fakeUser by ID
   const fakeUser = selectConnectionById(getState(), id);
-  const api = selectNodeApi(getState());
 
   if (!fakeUser) {
     console.log(`Failed to get fake connection id ${id}`);

--- a/BrightID/src/actions/fetchUserInfo.ts
+++ b/BrightID/src/actions/fetchUserInfo.ts
@@ -1,8 +1,8 @@
 import { InteractionManager } from 'react-native';
 import _ from 'lodash';
-import api from '@/api/brightId';
 import { updateInvites } from '@/utils/invites';
 import { GROUPS_TYPE } from '@/utils/constants';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import {
   setGroups,
   setInvites,
@@ -22,6 +22,7 @@ const fetchUserInfo = () => (dispatch: dispatch, getState: getState) => {
         user: { id },
         groups: { invites: oldInvites },
       } = getState();
+      const api = selectNodeApi(getState());
 
       const opTotal = selectOperationsTotal(getState());
       console.log('opTotal', opTotal);

--- a/BrightID/src/actions/fetchUserInfo.ts
+++ b/BrightID/src/actions/fetchUserInfo.ts
@@ -2,7 +2,7 @@ import { InteractionManager } from 'react-native';
 import _ from 'lodash';
 import { updateInvites } from '@/utils/invites';
 import { GROUPS_TYPE } from '@/utils/constants';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApi } from '@/api/brightId';
 import {
   setGroups,
   setInvites,
@@ -15,14 +15,17 @@ import {
   selectOperationsTotal,
 } from './index';
 
-const fetchUserInfo = () => (dispatch: dispatch, getState: getState) => {
+const fetchUserInfo = (api: NodeApi) => (
+  dispatch: dispatch,
+  getState: getState,
+) => {
   return new Promise((resolve) => {
     InteractionManager.runAfterInteractions(async () => {
       const {
         user: { id },
         groups: { invites: oldInvites },
       } = getState();
-      const api = selectNodeApi(getState());
+      // const api = selectNodeApi(getState());
 
       const opTotal = selectOperationsTotal(getState());
       console.log('opTotal', opTotal);

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -182,6 +182,7 @@ export class NodeApi {
     const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
     op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
     NodeApi.throwOnError(res);
+    return op;
   }
 
   async addAdmin(newAdmin: string, group: string) {

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -17,7 +17,7 @@ if (__DEV__) {
 }
 const v = 5;
 
-class NodeApi {
+export class NodeApi {
   api: ApisauceInstance;
 
   baseUrlInternal: string;

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -22,9 +22,8 @@ class NodeApi {
 
   baseUrlInternal: string;
 
-  constructor() {
-    // for now set the baseUrl to the seedUrl since there is only one server
-    this.baseUrlInternal = seedUrl;
+  constructor(url: string) {
+    this.baseUrlInternal = url;
     this.api = create({
       baseURL: this.apiUrl,
       headers: { 'Cache-Control': 'no-cache' },
@@ -429,6 +428,6 @@ class NodeApi {
   }
 }
 
-const brightId = new NodeApi();
+const brightId = new NodeApi(seedUrl);
 
 export default brightId;

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -16,9 +16,9 @@ export class NodeApi {
 
   baseUrlInternal: string;
 
-  secretKey: Uint8Array;
+  secretKey: Uint8Array | undefined;
 
-  id: string;
+  id: string | undefined;
 
   constructor({
     url,
@@ -26,8 +26,8 @@ export class NodeApi {
     id,
   }: {
     url: string;
-    secretKey: Uint8Array;
-    id: string;
+    secretKey: Uint8Array | undefined;
+    id: string | undefined;
   }) {
     this.baseUrlInternal = url;
     this.id = id;
@@ -68,6 +68,12 @@ export class NodeApi {
     }
   }
 
+  requiresCredentials() {
+    if (this.id === undefined || this.secretKey === undefined) {
+      throw new Error('Missing API credentials');
+    }
+  }
+
   async addConnection(
     id1: string,
     id2: string,
@@ -76,6 +82,7 @@ export class NodeApi {
     reportReason?: string,
     fakeUser?: FakeUser,
   ) {
+    this.requiresCredentials();
     const sk = fakeUser ? b64ToUint8Array(fakeUser.secretKey) : this.secretKey;
 
     const name = 'Connect';
@@ -111,6 +118,7 @@ export class NodeApi {
     url: string,
     type: string,
   ) {
+    this.requiresCredentials();
     const name = 'Add Group';
     const timestamp = Date.now();
 
@@ -139,6 +147,7 @@ export class NodeApi {
   }
 
   async dismiss(id2: string, group: string) {
+    this.requiresCredentials();
     const name = 'Dismiss';
     const timestamp = Date.now();
 
@@ -162,6 +171,7 @@ export class NodeApi {
   }
 
   async invite(id2: string, group: string, data: string) {
+    this.requiresCredentials();
     const name = 'Invite';
     const timestamp = Date.now();
 
@@ -186,6 +196,7 @@ export class NodeApi {
   }
 
   async addAdmin(newAdmin: string, group: string) {
+    this.requiresCredentials();
     const name = 'Add Admin';
     const timestamp = Date.now();
 
@@ -210,6 +221,7 @@ export class NodeApi {
   }
 
   async deleteGroup(group: string) {
+    this.requiresCredentials();
     const name = 'Remove Group';
     const timestamp = Date.now();
 
@@ -232,6 +244,7 @@ export class NodeApi {
   }
 
   async joinGroup(group: string, fakeUser?: FakeUser) {
+    this.requiresCredentials();
     let brightId, secretKey;
     if (fakeUser) {
       brightId = fakeUser.id;
@@ -264,6 +277,7 @@ export class NodeApi {
   }
 
   async leaveGroup(group: string) {
+    this.requiresCredentials();
     const name = 'Remove Membership';
     const timestamp = Date.now();
 
@@ -314,6 +328,7 @@ export class NodeApi {
   }
 
   async linkContextId(context: string, contextId: string) {
+    this.requiresCredentials();
     const name = 'Link ContextId';
     const timestamp = Date.now();
 
@@ -343,6 +358,7 @@ export class NodeApi {
   }
 
   async getUserProfile(id: string) {
+    this.requiresCredentials();
     const requester = this.id;
     const res = await this.api.get<UserProfileRes, ErrRes>(
       `/users/${id}/profile/${requester}`,

--- a/BrightID/src/components/Apps/AppCard.tsx
+++ b/BrightID/src/components/Apps/AppCard.tsx
@@ -41,7 +41,9 @@ const AppCard = (props: AppInfo) => {
   console.log('linkedContext', linkedContext);
   const { t } = useTranslation();
 
-  const verified = verifications.some((v) => v.app && id === v.name);
+  const verified = verifications.some(
+    (v: AppVerification) => v.app && id === v.name,
+  );
   const isLinked = linkedContext && linkedContext.state === 'applied';
   const notSponsored = unusedSponsorships < 1 || !unusedSponsorships;
 

--- a/BrightID/src/components/Apps/AppsScreen.tsx
+++ b/BrightID/src/components/Apps/AppsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import {
   Alert,
   StyleSheet,
@@ -22,6 +22,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import { fontSize } from '@/theme/fonts';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import AppCard from './AppCard';
 import { handleAppContext } from './model';
 
@@ -29,6 +30,7 @@ export const AppsScreen = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const route = useRoute<AppsRoute>();
+  const api = useContext(NodeApiContext);
 
   const apps = useSelector((state: State) => state.apps.apps);
   const isSponsored = useSelector((state: State) => state.user.isSponsored);
@@ -39,7 +41,7 @@ export const AppsScreen = () => {
 
   const refreshApps = useCallback(() => {
     setRefreshing(true);
-    dispatch(fetchApps())
+    dispatch(fetchApps(api))
       .then(() => {
         setRefreshing(false);
       })
@@ -47,7 +49,7 @@ export const AppsScreen = () => {
         console.log(err.message);
         setRefreshing(false);
       });
-  }, [dispatch]);
+  }, [api, dispatch]);
 
   useFocusEffect(refreshApps);
 

--- a/BrightID/src/components/Apps/model.ts
+++ b/BrightID/src/components/Apps/model.ts
@@ -1,8 +1,8 @@
 import { Alert } from 'react-native';
-import api from '@/api/brightId';
 import { addLinkedContext } from '@/actions';
 import store from '@/store';
 import i18next from 'i18next';
+import { NodeApi } from '@/api/brightId';
 
 export const handleAppContext = async (params: Params) => {
   // if 'params' is defined, the user came through a deep link
@@ -30,9 +30,9 @@ const linkContextId = async (
   context: string,
   contextId: string,
 ) => {
-  const oldBaseUrl = api.baseUrl;
+  // Create specific API object, since only the node at the specified baseUrl knows about this context
+  const api = new NodeApi(baseUrl);
   try {
-    api.baseUrl = baseUrl;
     await api.linkContextId(context, contextId);
     store.dispatch(
       addLinkedContext({
@@ -50,7 +50,5 @@ const linkContextId = async (
         onPress: () => null,
       },
     ]);
-  } finally {
-    api.baseUrl = oldBaseUrl;
   }
 };

--- a/BrightID/src/components/Apps/model.ts
+++ b/BrightID/src/components/Apps/model.ts
@@ -1,5 +1,5 @@
 import { Alert } from 'react-native';
-import { addLinkedContext } from '@/actions';
+import { addLinkedContext, addOperation } from '@/actions';
 import store from '@/store';
 import i18next from 'i18next';
 import { NodeApi } from '@/api/brightId';
@@ -30,10 +30,13 @@ const linkContextId = async (
   context: string,
   contextId: string,
 ) => {
-  // Create specific API object, since only the node at the specified baseUrl knows about this context
-  const api = new NodeApi(baseUrl);
+  // Create temporary NodeAPI object, since only the node at the specified baseUrl knows about this context
+  const { id } = store.getState().user;
+  const { secretKey } = store.getState().keypair;
+  const api = new NodeApi({ url: baseUrl, id, secretKey });
   try {
-    await api.linkContextId(context, contextId);
+    const op = await api.linkContextId(context, contextId);
+    store.dispatch(addOperation(op));
     store.dispatch(
       addLinkedContext({
         context,

--- a/BrightID/src/components/Connections/ConnectionScreenController.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreenController.tsx
@@ -12,11 +12,11 @@ import {
   RouteProp,
 } from '@react-navigation/native';
 import ConnectionTestButton from '@/utils/connectionTestButton';
-import api from '@/api/brightId';
 import {
   selectConnectionById,
   selectAllConnections,
 } from '@/reducer/connectionsSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import ConnectionScreen from './ConnectionScreen';
 
 type ConnectionRoute = RouteProp<
@@ -28,6 +28,7 @@ function ConnectionScreenController() {
   const navigation = useNavigation();
   const route = useRoute<ConnectionRoute>();
   const { connectionId } = route.params;
+  const api = useSelector(selectNodeApi);
   const connection = useSelector((state: State) =>
     selectConnectionById(state, connectionId),
   );
@@ -64,7 +65,7 @@ function ConnectionScreenController() {
       if (connectionId !== undefined) {
         fetchData(connectionId);
       }
-    }, [myConnections, myGroups, connectionId]),
+    }, [connectionId, api, myConnections, myGroups]),
   );
 
   useEffect(() => {

--- a/BrightID/src/components/Connections/ConnectionScreenController.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreenController.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useState,
@@ -16,7 +17,7 @@ import {
   selectConnectionById,
   selectAllConnections,
 } from '@/reducer/connectionsSlice';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import ConnectionScreen from './ConnectionScreen';
 
 type ConnectionRoute = RouteProp<
@@ -28,7 +29,7 @@ function ConnectionScreenController() {
   const navigation = useNavigation();
   const route = useRoute<ConnectionRoute>();
   const { connectionId } = route.params;
-  const api = useSelector(selectNodeApi);
+  const api = useContext(NodeApiContext);
   const connection = useSelector((state: State) =>
     selectConnectionById(state, connectionId),
   );

--- a/BrightID/src/components/Connections/ConnectionsScreen.tsx
+++ b/BrightID/src/components/Connections/ConnectionsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { StyleSheet, View, StatusBar, FlatList } from 'react-native';
 import { useDispatch, useSelector } from '@/store';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +10,7 @@ import { connectionsSelector } from '@/utils/connectionsSelector';
 import { ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import ConnectionCard from './ConnectionCard';
 
 /**
@@ -35,6 +36,7 @@ const renderItem = ({ item, index }: { item: Connection; index: number }) => {
 export const ConnectionsScreen = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const api = useContext(NodeApiContext);
 
   const connections = useSelector(connectionsSelector);
   const { t } = useTranslation();
@@ -46,7 +48,7 @@ export const ConnectionsScreen = () => {
   const ConnectionList = useMemo(() => {
     const onRefresh = async () => {
       try {
-        await dispatch(fetchUserInfo());
+        await dispatch(fetchUserInfo(api));
       } catch (err) {
         console.log(err.message);
       }

--- a/BrightID/src/components/Connections/ReportReasonModal.tsx
+++ b/BrightID/src/components/Connections/ReportReasonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import i18next from 'i18next';
 import { BlurView } from '@react-native-community/blur';
@@ -11,6 +11,7 @@ import { ORANGE, WHITE, BLUE, BLACK, DARKER_GREY, GREEN } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import { StackScreenProps } from '@react-navigation/stack';
 import { selectConnectionById } from '@/reducer/connectionsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { reportConnection } from './models/reportConnection';
 
 const reasonStrings = {
@@ -30,6 +31,7 @@ type props = StackScreenProps<ModalStackParamList, 'ReportReason'>;
 const ReportReasonModal = ({ route, navigation }: props) => {
   const { connectionId, successCallback } = route.params;
   const { t } = useTranslation();
+  const api = useContext(NodeApiContext);
   const connection: Connection = useSelector((state: State) =>
     selectConnectionById(state, connectionId),
   );
@@ -49,7 +51,7 @@ const ReportReasonModal = ({ route, navigation }: props) => {
       );
       // close modal
       navigation.goBack();
-      dispatch(reportConnection({ id: connectionId, reason }));
+      dispatch(reportConnection({ id: connectionId, reason, api }));
       if (successCallback) {
         successCallback();
       }

--- a/BrightID/src/components/Connections/TrustlevelModal.tsx
+++ b/BrightID/src/components/Connections/TrustlevelModal.tsx
@@ -17,13 +17,13 @@ import { BLACK, WHITE, GREEN } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { useDispatch, useSelector } from '@/store';
-import api from '@/api/brightId';
-import { setConnectionLevel } from '@/actions';
+import { addOperation, setConnectionLevel } from '@/actions';
 import { calculateCooldownPeriod } from '@/utils/recovery';
 import {
   selectConnectionById,
   recoveryConnectionsSelector,
 } from '@/reducer/connectionsSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import TrustlevelSlider from './TrustlevelSlider';
 
 type props = StackScreenProps<ModalStackParamList, 'SetTrustlevel'>;
@@ -41,6 +41,7 @@ const TrustlevelModal = ({ route, navigation }: props) => {
     connection ? connection.level : connection_levels.JUST_MET,
   );
   const { t } = useTranslation();
+  const api = useSelector(selectNodeApi);
 
   const saveLevelHandler = async () => {
     let cooldownPeriod = 0;
@@ -56,7 +57,13 @@ const TrustlevelModal = ({ route, navigation }: props) => {
         // removing recovery connection. Cooldown period always applies
         cooldownPeriod = RECOVERY_COOLDOWN_DURATION;
       }
-      await api.addConnection(myId, connection.id, level, Date.now());
+      const op = await api.addConnection(
+        myId,
+        connection.id,
+        level,
+        Date.now(),
+      );
+      dispatch(addOperation(op));
       dispatch(setConnectionLevel({ id: connection.id, level }));
     }
     // close modal

--- a/BrightID/src/components/Connections/TrustlevelModal.tsx
+++ b/BrightID/src/components/Connections/TrustlevelModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   View,
   StyleSheet,
@@ -23,7 +23,7 @@ import {
   selectConnectionById,
   recoveryConnectionsSelector,
 } from '@/reducer/connectionsSlice';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import TrustlevelSlider from './TrustlevelSlider';
 
 type props = StackScreenProps<ModalStackParamList, 'SetTrustlevel'>;
@@ -41,7 +41,7 @@ const TrustlevelModal = ({ route, navigation }: props) => {
     connection ? connection.level : connection_levels.JUST_MET,
   );
   const { t } = useTranslation();
-  const api = useSelector(selectNodeApi);
+  const api = useContext(NodeApiContext);
 
   const saveLevelHandler = async () => {
     let cooldownPeriod = 0;

--- a/BrightID/src/components/Connections/models/reportConnection.ts
+++ b/BrightID/src/components/Connections/models/reportConnection.ts
@@ -1,15 +1,16 @@
 import { addOperation, deleteConnection } from '@/actions';
 import { backupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import { connection_levels } from '@/utils/constants';
-import { useSelector } from '@/store';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApi } from '@/api/brightId';
 
 export const reportConnection = ({
   id,
   reason,
+  api,
 }: {
   id: string;
   reason: string;
+  api: NodeApi;
 }) => async (dispatch: Dispatch, getState: GetState) => {
   try {
     const {
@@ -17,7 +18,6 @@ export const reportConnection = ({
     } = getState();
 
     // Change connection to REPORTED level
-    const api = selectNodeApi(getState());
     const op = await api.addConnection(
       brightId,
       id,

--- a/BrightID/src/components/Connections/models/reportConnection.ts
+++ b/BrightID/src/components/Connections/models/reportConnection.ts
@@ -1,7 +1,8 @@
-import api from '@/api/brightId';
-import { deleteConnection } from '@/actions';
+import { addOperation, deleteConnection } from '@/actions';
 import { backupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import { connection_levels } from '@/utils/constants';
+import { useSelector } from '@/store';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
 export const reportConnection = ({
   id,
@@ -16,13 +17,15 @@ export const reportConnection = ({
     } = getState();
 
     // Change connection to REPORTED level
-    await api.addConnection(
+    const api = selectNodeApi(getState());
+    const op = await api.addConnection(
       brightId,
       id,
       connection_levels.REPORTED,
       Date.now(),
       reason,
     );
+    dispatch(addOperation(op));
     // remove connection from local storage
     dispatch(deleteConnection(id));
     if (backupCompleted) {

--- a/BrightID/src/components/Groups/GroupsScreen.js
+++ b/BrightID/src/components/Groups/GroupsScreen.js
@@ -17,6 +17,7 @@ import { WHITE, ORANGE, BLACK } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { toSearchString } from '@/utils/strings';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import GroupCard from './GroupCard';
 import { NoGroups } from './NoGroups';
 import { compareJoinedDesc } from './models/sortingUtility';
@@ -39,6 +40,9 @@ const getItemLayout = (data, index) => ({
 });
 
 export class GroupsScreen extends React.Component {
+  // make api available through this.context
+  static contextType = NodeApiContext;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -48,8 +52,9 @@ export class GroupsScreen extends React.Component {
 
   componentDidMount() {
     const { navigation, dispatch } = this.props;
+    const api = this.context;
     navigation.addListener('focus', () => {
-      dispatch(fetchUserInfo());
+      dispatch(fetchUserInfo(api));
     });
   }
 
@@ -68,8 +73,9 @@ export class GroupsScreen extends React.Component {
   onRefresh = async () => {
     try {
       const { dispatch } = this.props;
+      const api = this.context;
       this.setState({ refreshing: true });
-      await dispatch(fetchUserInfo());
+      await dispatch(fetchUserInfo(api));
       this.setState({ refreshing: false });
     } catch (err) {
       console.log(err.message);

--- a/BrightID/src/components/Groups/Members/InviteListScreen.js
+++ b/BrightID/src/components/Groups/Members/InviteListScreen.js
@@ -13,7 +13,7 @@ import EmptyList from '@/components/Helpers/EmptyList';
 import { ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import i18next from 'i18next';
-import { selectAllConnections } from '@/actions';
+import { addOperation, selectAllConnections } from '@/actions';
 import { selectNodeApi } from '@/reducer/settingsSlice';
 import MemberCard from './MemberCard';
 
@@ -39,12 +39,13 @@ export class InviteListScreen extends Component {
   };
 
   inviteToGroup = async (connection) => {
-    const { navigation, route, api } = this.props;
+    const { navigation, route, api, dispatch } = this.props;
     const group = route.params?.group;
 
     try {
       const data = await encryptAesKey(group?.aesKey, connection.signingKey);
-      await api.invite(connection.id, group?.id, data);
+      const op = await api.invite(connection.id, group?.id, data);
+      dispatch(addOperation(op));
       Alert.alert(
         i18next.t('groups.alert.title.inviteSuccess'),
         i18next.t('groups.alert.text.inviteSuccess', { name: connection.name }),

--- a/BrightID/src/components/Groups/Members/InviteListScreen.js
+++ b/BrightID/src/components/Groups/Members/InviteListScreen.js
@@ -8,13 +8,13 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import api from '@/api/brightId';
 import { encryptAesKey } from '@/utils/invites';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import i18next from 'i18next';
 import { selectAllConnections } from '@/actions';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import MemberCard from './MemberCard';
 
 const ITEM_HEIGHT = DEVICE_LARGE ? 94 : 80;
@@ -39,7 +39,7 @@ export class InviteListScreen extends Component {
   };
 
   inviteToGroup = async (connection) => {
-    const { navigation, route } = this.props;
+    const { navigation, route, api } = this.props;
     const group = route.params?.group;
 
     try {
@@ -123,4 +123,5 @@ const styles = StyleSheet.create({
 
 export default connect((state) => ({
   connections: selectAllConnections(state),
+  api: selectNodeApi(state),
 }))(withTranslation()(InviteListScreen));

--- a/BrightID/src/components/Groups/Members/InviteListScreen.js
+++ b/BrightID/src/components/Groups/Members/InviteListScreen.js
@@ -14,7 +14,7 @@ import { ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import i18next from 'i18next';
 import { addOperation, selectAllConnections } from '@/actions';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import MemberCard from './MemberCard';
 
 const ITEM_HEIGHT = DEVICE_LARGE ? 94 : 80;
@@ -27,6 +27,9 @@ const getItemLayout = (data, index) => ({
 });
 
 export class InviteListScreen extends Component {
+  // make api available through this.context
+  static contextType = NodeApiContext;
+
   renderEligible = ({ item, index }) => {
     return (
       <TouchableOpacity
@@ -39,7 +42,8 @@ export class InviteListScreen extends Component {
   };
 
   inviteToGroup = async (connection) => {
-    const { navigation, route, api, dispatch } = this.props;
+    const { navigation, route, dispatch } = this.props;
+    let api = this.context;
     const group = route.params?.group;
 
     try {
@@ -124,5 +128,4 @@ const styles = StyleSheet.create({
 
 export default connect((state) => ({
   connections: selectAllConnections(state),
-  api: selectNodeApi(state),
 }))(withTranslation()(InviteListScreen));

--- a/BrightID/src/components/Groups/Members/MembersScreen.js
+++ b/BrightID/src/components/Groups/Members/MembersScreen.js
@@ -10,7 +10,6 @@ import { useDispatch, useSelector } from '@/store';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { innerJoin } from 'ramda';
 import { useTranslation } from 'react-i18next';
-import api from '@/api/brightId';
 import {
   leaveGroup,
   dismissFromGroup,
@@ -23,12 +22,15 @@ import Material from 'react-native-vector-icons/MaterialCommunityIcons';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { groupByIdSelector } from '@/utils/groups';
+import { selectNodeApi } from '@/reducer/settingsSlice';
+import { addOperation } from '@/reducer/operationsSlice';
 import MemberCard from './MemberCard';
 
 function MembersScreen(props) {
   const { navigation, route } = props;
   const groupID = route.params.group.id;
   const dispatch = useDispatch();
+  const api = useSelector(selectNodeApi);
   const connections = useSelector(selectAllConnections);
   const user = useSelector((state) => state.user);
   const { group, admins, members } = useSelector((state) =>
@@ -58,7 +60,8 @@ function MembersScreen(props) {
             text: t('common.alert.ok'),
             onPress: async () => {
               try {
-                await api.leaveGroup(groupID);
+                const op = await api.leaveGroup(groupID);
+                dispatch(addOperation(op));
                 await dispatch(leaveGroup(group));
                 navigation.goBack();
               } catch (err) {
@@ -146,6 +149,7 @@ function MembersScreen(props) {
     ACTION_LEAVE,
     ACTION_CANCEL,
     ACTION_INVITE,
+    api,
   ]);
 
   // set available actions for group
@@ -200,7 +204,8 @@ function MembersScreen(props) {
         text: t('common.alert.ok'),
         onPress: async () => {
           try {
-            await api.dismiss(user.id, groupID);
+            const op = await api.dismiss(user.id, groupID);
+            dispatch(addOperation(op));
             dispatch(dismissFromGroup({ member: user.id, group }));
           } catch (err) {
             Alert.alert(
@@ -232,7 +237,8 @@ function MembersScreen(props) {
         text: t('common.alert.ok'),
         onPress: async () => {
           try {
-            await api.addAdmin(user.id, groupID);
+            const op = await api.addAdmin(user.id, groupID);
+            dispatch(addOperation(op));
             dispatch(addAdmin({ member: user.id, group }));
           } catch (err) {
             Alert.alert(

--- a/BrightID/src/components/Groups/Members/MembersScreen.js
+++ b/BrightID/src/components/Groups/Members/MembersScreen.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useLayoutEffect, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useContext,
+} from 'react';
 import {
   StyleSheet,
   View,
@@ -22,15 +28,15 @@ import Material from 'react-native-vector-icons/MaterialCommunityIcons';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { groupByIdSelector } from '@/utils/groups';
-import { selectNodeApi } from '@/reducer/settingsSlice';
 import { addOperation } from '@/reducer/operationsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import MemberCard from './MemberCard';
 
 function MembersScreen(props) {
   const { navigation, route } = props;
   const groupID = route.params.group.id;
   const dispatch = useDispatch();
-  const api = useSelector(selectNodeApi);
+  const api = useContext(NodeApiContext);
   const connections = useSelector(selectAllConnections);
   const user = useSelector((state) => state.user);
   const { group, admins, members } = useSelector((state) =>

--- a/BrightID/src/components/Groups/NewGroups/NewGroupScreen.js
+++ b/BrightID/src/components/Groups/NewGroups/NewGroupScreen.js
@@ -18,6 +18,7 @@ import { connectionsSelector } from '@/utils/connectionsSelector';
 import { createSelector } from '@reduxjs/toolkit';
 import Spinner from 'react-native-spinkit';
 import i18next from 'i18next';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { createNewGroup } from '../actions';
 import NewGroupCard from './NewGroupCard';
 
@@ -50,6 +51,9 @@ const creationStateStrings = {
 };
 
 export class NewGroupScreen extends React.Component {
+  // make api available through this.context
+  static contextType = NodeApiContext;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -81,10 +85,11 @@ export class NewGroupScreen extends React.Component {
   createGroup = async () => {
     try {
       this.setState({ creating: true });
+      const api = this.context;
       const { route, navigation } = this.props;
       const { photo, name, isPrimary } = route.params;
       const type = isPrimary ? 'primary' : 'general';
-      const res = await store.dispatch(createNewGroup(photo, name, type));
+      const res = await store.dispatch(createNewGroup(photo, name, type, api));
       if (res) {
         navigation.navigate('Groups');
       } else {

--- a/BrightID/src/components/Groups/actions.js
+++ b/BrightID/src/components/Groups/actions.js
@@ -8,7 +8,6 @@ import { setNewGroupCoFounders, createGroup } from '@/actions/index';
 import backupApi from '@/api/backupService';
 import { hash, randomKey } from '@/utils/encoding';
 import { selectConnectionById } from '@/reducer/connectionsSlice';
-import { selectNodeApi } from '@/reducer/settingsSlice';
 import { addOperation } from '@/reducer/operationsSlice';
 import {
   backupPhoto,
@@ -26,7 +25,7 @@ export const toggleNewGroupCoFounder = (id) => (dispatch, getState) => {
   dispatch(setNewGroupCoFounders(coFounders));
 };
 
-export const createNewGroup = (photo, name, type) => async (
+export const createNewGroup = (photo, name, type, api) => async (
   dispatch,
   getState,
 ) => {
@@ -51,7 +50,6 @@ export const createNewGroup = (photo, name, type) => async (
         throw new Error(`${name} already has a primary group`);
       }
     }
-    const api = selectNodeApi(getState());
 
     const aesKey = await randomKey(16);
     const uuidKey = await randomKey(9);

--- a/BrightID/src/components/Groups/actions.js
+++ b/BrightID/src/components/Groups/actions.js
@@ -5,10 +5,11 @@ import emitter from '@/emitter';
 import { saveImage } from '@/utils/filesystem';
 import { encryptAesKey } from '@/utils/invites';
 import { setNewGroupCoFounders, createGroup } from '@/actions/index';
-import api from '@/api/brightId';
 import backupApi from '@/api/backupService';
 import { hash, randomKey } from '@/utils/encoding';
 import { selectConnectionById } from '@/reducer/connectionsSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
+import { addOperation } from '@/reducer/operationsSlice';
 import {
   backupPhoto,
   backupUser,
@@ -50,6 +51,7 @@ export const createNewGroup = (photo, name, type) => async (
         throw new Error(`${name} already has a primary group`);
       }
     }
+    const api = selectNodeApi(getState());
 
     const aesKey = await randomKey(16);
     const uuidKey = await randomKey(9);
@@ -93,7 +95,7 @@ export const createNewGroup = (photo, name, type) => async (
 
     const inviteData3 = await encryptAesKey(aesKey, founder3.signingKey);
 
-    await api.createGroup(
+    const op = await api.createGroup(
       groupId,
       founder2.id,
       inviteData2,
@@ -102,6 +104,7 @@ export const createNewGroup = (photo, name, type) => async (
       url,
       type,
     );
+    dispatch(addOperation(op));
 
     dispatch(createGroup(newGroup));
 

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -31,7 +31,7 @@ import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { setHeaderHeight } from '@/reducer/walkthroughSlice';
 import { uniq } from 'ramda';
-import { selectBaseUrl } from '@/reducer/settingsSlice';
+import { clearBaseUrl, selectBaseUrl } from '@/reducer/settingsSlice';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import { version as app_version } from '../../package.json';
 
@@ -343,10 +343,21 @@ export const HomeScreen = (props) => {
               </Text>
             </View>
           </TouchableOpacity>
+          {__DEV__ && (
+            <TouchableOpacity
+              style={styles.nodeInfoContainer}
+              onPress={() => {
+                dispatch(clearBaseUrl());
+              }}
+            >
+              <View>
+                <Text style={styles.nodeInfo}>{baseUrl}</Text>
+              </View>
+            </TouchableOpacity>
+          )}
         </View>
         <DeepPasteLink />
         <Text style={styles.versionInfo}>v{app_version}</Text>
-        {__DEV__ && <Text style={styles.nodeInfo}>{baseUrl}</Text>}
       </View>
     </View>
   );
@@ -536,13 +547,14 @@ const styles = StyleSheet.create({
     right: DEVICE_LARGE ? 12 : 7,
     bottom: DEVICE_LARGE ? 12 : 7,
   },
+  nodeInfoContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   nodeInfo: {
     fontFamily: 'Poppins-Regular',
     fontSize: fontSize[12],
     color: WHITE,
-    position: 'absolute',
-    left: 50,
-    bottom: DEVICE_LARGE ? 12 : 7,
   },
 });
 

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -32,6 +32,7 @@ import { fontSize } from '@/theme/fonts';
 import { setHeaderHeight } from '@/reducer/walkthroughSlice';
 import { uniq } from 'ramda';
 import { selectBaseUrl } from '@/reducer/settingsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { version as app_version } from '../../package.json';
 
 /**
@@ -70,6 +71,7 @@ export const HomeScreen = (props) => {
   const baseUrl = useSelector(selectBaseUrl);
   const [profilePhoto, setProfilePhoto] = useState('');
   const [loading, setLoading] = useState(true);
+  const api = useContext(NodeApiContext);
 
   const { t } = useTranslation();
 
@@ -77,7 +79,7 @@ export const HomeScreen = (props) => {
     useCallback(() => {
       retrieveImage(photoFilename).then(setProfilePhoto);
       setLoading(true);
-      dispatch(fetchUserInfo()).then(() => {
+      dispatch(fetchUserInfo(api)).then(() => {
         setLoading(false);
       });
       const timeoutId = setTimeout(() => {
@@ -86,7 +88,7 @@ export const HomeScreen = (props) => {
       return () => {
         clearTimeout(timeoutId);
       };
-    }, [dispatch, photoFilename]),
+    }, [api, dispatch, photoFilename]),
   );
 
   useEffect(() => {

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -344,7 +344,7 @@ export const HomeScreen = (props) => {
         </View>
         <DeepPasteLink />
         <Text style={styles.versionInfo}>v{app_version}</Text>
-        <Text style={styles.versionInfo}>Node: {baseUrl.href}</Text>
+        {__DEV__ && <Text style={styles.nodeInfo}>{baseUrl}</Text>}
       </View>
     </View>
   );
@@ -532,6 +532,14 @@ const styles = StyleSheet.create({
     color: WHITE,
     position: 'absolute',
     right: DEVICE_LARGE ? 12 : 7,
+    bottom: DEVICE_LARGE ? 12 : 7,
+  },
+  nodeInfo: {
+    fontFamily: 'Poppins-Regular',
+    fontSize: fontSize[12],
+    color: WHITE,
+    position: 'absolute',
+    left: 50,
     bottom: DEVICE_LARGE ? 12 : 7,
   },
 });

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -31,6 +31,7 @@ import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { setHeaderHeight } from '@/reducer/walkthroughSlice';
 import { uniq } from 'ramda';
+import { selectBaseUrl } from '@/reducer/settingsSlice';
 import { version as app_version } from '../../package.json';
 
 /**
@@ -43,7 +44,7 @@ const discordUrl = 'https://discord.gg/nTtuB2M';
 
 export const verifiedAppsSelector = createSelector(
   (state: State) => state.user.verifications,
-  (verifications) => verifications.filter((v) => v.app),
+  (verifications) => verifications.filter((v) => (v as AppVerification).app),
 );
 
 export const brightIdVerifiedSelector = createSelector(
@@ -66,6 +67,7 @@ export const HomeScreen = (props) => {
   const linkedContextsCount = useSelector(linkedContextTotal);
   const verifiedApps = useSelector(verifiedAppsSelector);
   const brightIdVerified = useSelector(brightIdVerifiedSelector);
+  const baseUrl = useSelector(selectBaseUrl);
   const [profilePhoto, setProfilePhoto] = useState('');
   const [loading, setLoading] = useState(true);
 
@@ -342,6 +344,7 @@ export const HomeScreen = (props) => {
         </View>
         <DeepPasteLink />
         <Text style={styles.versionInfo}>v{app_version}</Text>
+        <Text style={styles.versionInfo}>Node: {baseUrl.href}</Text>
       </View>
     </View>
   );

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -8,9 +8,11 @@ import { pollOperations } from '@/utils/operations';
 export const NodeApiContext = React.createContext(null);
 
 const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
-  const id = useSelector((state: State) => state.user.id);
-  const secretKey = useSelector((state: State) => state.keypair.secretKey);
-  const url = useSelector(selectBaseUrl);
+  const id = useSelector<string>((state: State) => state.user.id);
+  const secretKey = useSelector<Uint8Array>(
+    (state: State) => state.keypair.secretKey,
+  );
+  const url = useSelector<string>(selectBaseUrl);
   const [api, setApi] = useState<NodeApi | null>(null);
   const dispatch = useDispatch();
 

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -17,7 +17,7 @@ const ProdCandidates = [
   'http://node.lumos.services',
   'http://brightid.daosquare.io',
 ];
-const TestCandidates = ['http://test.brightid.org2'];
+const TestCandidates = ['http://test.brightid.org'];
 
 export const ApiGateState = {
   INITIAL: 'INITIAL',
@@ -62,17 +62,18 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
   useEffect(() => {
     const runEffect = async () => {
       console.log(`Running nodechooser to select backend`);
-      setGateState(ApiGateState.SEARCHING_NODE);
       setStartTimestamp(Date.now());
+      setGateState(ApiGateState.SEARCHING_NODE);
       try {
         const fastestUrl = await chooseNode(
           __DEV__ ? TestCandidates : ProdCandidates,
         );
         dispatch(setBaseUrl(fastestUrl));
-        setStartTimestamp(0);
       } catch (e) {
         // No usable node found :-(
         setGateState(ApiGateState.ERROR_NO_NODE);
+      } finally {
+        setStartTimestamp(0);
       }
     };
     if (gateState === ApiGateState.SEARCH_REQUESTED) {

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -11,11 +11,12 @@ export const NodeApiContext = React.createContext(null);
 const ProdCandidates = [
   'http://node.brightid.org',
   'http://brightid.idealmoney.io',
-  'http://brightid.onehive.org',
-  'http://085e67e8aeaf31f0.dyndns.dappnode.io',
-  'http://node.topupgifter.com',
-  'http://node.lumos.services',
-  'http://brightid.daosquare.io',
+  'https://brightid.085e67e8aeaf31f0.dyndns.dappnode.io',
+  // Following nodes exist, but currently fail the NodeChooser tests
+  //  'http://brightid.onehive.org',
+  //  'http://node.topupgifter.com',
+  //  'http://node.lumos.services',
+  //  'http://brightid.daosquare.io',
 ];
 const TestCandidates = ['http://test.brightid.org'];
 

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -1,0 +1,28 @@
+import { useDispatch, useSelector } from '@/store';
+import { initApiThunk, selectNodeApi } from '@/reducer/settingsSlice';
+import React, { useEffect } from 'react';
+import { View, Text } from 'react-native';
+
+const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
+  const api = useSelector(selectNodeApi);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (api === undefined) {
+      console.log(`Starting api initialization`);
+      dispatch(initApiThunk());
+    }
+  }, [api, dispatch]);
+
+  if (api) {
+    return <>{props.children}</>;
+  } else {
+    // TODO: waiting screen etc.
+    return (
+      <View>
+        <Text>Waiting for API</Text>
+      </View>
+    );
+  }
+};
+
+export default NodeApiGate;

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -10,16 +10,26 @@ export const NodeApiContext = React.createContext(null);
 const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
   const id = useSelector((state: State) => state.user.id);
   const secretKey = useSelector((state: State) => state.keypair.secretKey);
-  const baseUrl = useSelector(selectBaseUrl);
-  const [api, setApi] = useState(undefined);
+  const url = useSelector(selectBaseUrl);
+  const [api, setApi] = useState<NodeApi | null>(null);
   const dispatch = useDispatch();
 
-  // Maintain NodeAPI instance
+  // Create and maintain NodeAPI instance
   useEffect(() => {
-    console.log(`Creating API using ${baseUrl}`);
-    const apiInstance = new NodeApi({ url: baseUrl, id, secretKey });
+    let apiInstance;
+    if (id && id.length > 0 && secretKey && secretKey.length > 0) {
+      console.log(`Creating API with credentials using ${url}`);
+      apiInstance = new NodeApi({ url, id, secretKey });
+    } else {
+      console.log(`Creating anonymous API using ${url}`);
+      apiInstance = new NodeApi({
+        url,
+        id: undefined,
+        secretKey: undefined,
+      });
+    }
     setApi(apiInstance);
-  }, [baseUrl, dispatch, id, secretKey]);
+  }, [url, dispatch, id, secretKey]);
 
   useEffect(() => {
     // subscribe to operations

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -35,6 +35,7 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
   );
   const url = useSelector<string>(selectBaseUrl);
   const [api, setApi] = useState<NodeApi | null>(null);
+  const [startTimestamp, setStartTimestamp] = useState(0);
   const [gateState, setGateState] = useState<ApiGateState>(
     ApiGateState.INITIAL,
   );
@@ -62,11 +63,13 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
     const runEffect = async () => {
       console.log(`Running nodechooser to select backend`);
       setGateState(ApiGateState.SEARCHING_NODE);
+      setStartTimestamp(Date.now());
       try {
         const fastestUrl = await chooseNode(
           __DEV__ ? TestCandidates : ProdCandidates,
         );
         dispatch(setBaseUrl(fastestUrl));
+        setStartTimestamp(0);
       } catch (e) {
         // No usable node found :-(
         setGateState(ApiGateState.ERROR_NO_NODE);
@@ -125,7 +128,11 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
     );
   } else {
     return (
-      <NodeApiGateScreen gateState={gateState} retryHandler={retryHandler} />
+      <NodeApiGateScreen
+        gateState={gateState}
+        retryHandler={retryHandler}
+        startTimestamp={startTimestamp}
+      />
     );
   }
 };

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -1,20 +1,45 @@
 import { useDispatch, useSelector } from '@/store';
-import { initApiThunk, selectNodeApi } from '@/reducer/settingsSlice';
-import React, { useEffect } from 'react';
-import { View, Text } from 'react-native';
+import { selectBaseUrl } from '@/reducer/settingsSlice';
+import React, { useEffect, useState } from 'react';
+import { View, Text, InteractionManager } from 'react-native';
+import { NodeApi } from '@/api/brightId';
+import { pollOperations } from '@/utils/operations';
+
+export const NodeApiContext = React.createContext(null);
 
 const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
-  const api = useSelector(selectNodeApi);
+  const id = useSelector((state: State) => state.user.id);
+  const secretKey = useSelector((state: State) => state.keypair.secretKey);
+  const baseUrl = useSelector(selectBaseUrl);
+  const [api, setApi] = useState(undefined);
   const dispatch = useDispatch();
+
+  // Maintain NodeAPI instance
   useEffect(() => {
-    if (api === undefined) {
-      console.log(`Starting api initialization`);
-      dispatch(initApiThunk());
-    }
-  }, [api, dispatch]);
+    console.log(`Creating API using ${baseUrl}`);
+    const apiInstance = new NodeApi({ url: baseUrl, id, secretKey });
+    setApi(apiInstance);
+  }, [baseUrl, dispatch, id, secretKey]);
+
+  useEffect(() => {
+    // subscribe to operations
+    const timerId = setInterval(() => {
+      InteractionManager.runAfterInteractions(() => {
+        pollOperations(api);
+      });
+    }, 5000);
+
+    return () => {
+      clearInterval(timerId);
+    };
+  }, [api]);
 
   if (api) {
-    return <>{props.children}</>;
+    return (
+      <NodeApiContext.Provider value={api}>
+        {props.children}
+      </NodeApiContext.Provider>
+    );
   } else {
     // TODO: waiting screen etc.
     return (

--- a/BrightID/src/components/NodeApiGate.tsx
+++ b/BrightID/src/components/NodeApiGate.tsx
@@ -1,11 +1,29 @@
 import { useDispatch, useSelector } from '@/store';
-import { selectBaseUrl } from '@/reducer/settingsSlice';
+import { selectBaseUrl, setBaseUrl } from '@/reducer/settingsSlice';
 import React, { useEffect, useState } from 'react';
 import { View, Text, InteractionManager } from 'react-native';
 import { NodeApi } from '@/api/brightId';
 import { pollOperations } from '@/utils/operations';
+import chooseNode from '@/utils/nodeChooser';
 
 export const NodeApiContext = React.createContext(null);
+const ProdCandidates = [
+  'http://node.brightid.org',
+  'http://brightid.idealmoney.io',
+  'http://brightid.onehive.org',
+  'http://085e67e8aeaf31f0.dyndns.dappnode.io',
+  'http://node.topupgifter.com',
+  'http://node.lumos.services',
+  'http://brightid.daosquare.io',
+];
+const TestCandidates = ['http://test.brightid.org'];
+
+enum apiGateStates {
+  INITIAL,
+  SEARCHING_NODE, // currently looking for working node
+  NODE_AVAILABLE, // All good, valid node is set
+  ERROR_NO_NODE, // Failed to find a working node
+}
 
 const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
   const id = useSelector<string>((state: State) => state.user.id);
@@ -14,37 +32,86 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
   );
   const url = useSelector<string>(selectBaseUrl);
   const [api, setApi] = useState<NodeApi | null>(null);
+  const [gateState, setGateState] = useState<apiGateStates>(
+    apiGateStates.INITIAL,
+  );
   const dispatch = useDispatch();
 
-  // Create and maintain NodeAPI instance
+  // Run nodechooser if no baseUrl is set
   useEffect(() => {
-    let apiInstance;
-    if (id && id.length > 0 && secretKey && secretKey.length > 0) {
-      console.log(`Creating API with credentials using ${url}`);
-      apiInstance = new NodeApi({ url, id, secretKey });
-    } else {
-      console.log(`Creating anonymous API using ${url}`);
-      apiInstance = new NodeApi({
-        url,
-        id: undefined,
-        secretKey: undefined,
-      });
+    const runEffect = async () => {
+      console.log(`No baseUrl set. Running nodechooser to select backend`);
+      setGateState(apiGateStates.SEARCHING_NODE);
+      try {
+        const fastestUrl = await chooseNode(
+          __DEV__ ? TestCandidates : ProdCandidates,
+        );
+        dispatch(setBaseUrl(fastestUrl));
+      } catch (e) {
+        // No usable node found :-(
+        setGateState(apiGateStates.ERROR_NO_NODE);
+      }
+    };
+    if (!url) {
+      runEffect();
     }
-    setApi(apiInstance);
+  }, [dispatch, url]);
+
+  // Manage NodeAPI instance
+  useEffect(() => {
+    if (url) {
+      let apiInstance;
+      if (id && id.length > 0 && secretKey && secretKey.length > 0) {
+        console.log(`Creating API with credentials using ${url}`);
+        apiInstance = new NodeApi({ url, id, secretKey });
+      } else {
+        console.log(`Creating anonymous API using ${url}`);
+        apiInstance = new NodeApi({
+          url,
+          id: undefined,
+          secretKey: undefined,
+        });
+      }
+      setGateState(apiGateStates.NODE_AVAILABLE);
+      setApi(apiInstance);
+    } else {
+      setApi(null);
+    }
   }, [url, dispatch, id, secretKey]);
 
+  // Manage polling for operations
   useEffect(() => {
-    // subscribe to operations
-    const timerId = setInterval(() => {
-      InteractionManager.runAfterInteractions(() => {
-        pollOperations(api);
-      });
-    }, 5000);
+    if (api) {
+      // subscribe to operations
+      const timerId = setInterval(() => {
+        InteractionManager.runAfterInteractions(() => {
+          pollOperations(api);
+        });
+      }, 5000);
+      console.log(`Started pollOperationsTimer ${timerId}`);
 
-    return () => {
-      clearInterval(timerId);
-    };
+      return () => {
+        console.log(`Stop pollOperationsTimer ${timerId}`);
+        clearInterval(timerId);
+      };
+    }
   }, [api]);
+
+  let message: string;
+  switch (gateState) {
+    case apiGateStates.INITIAL:
+    case apiGateStates.SEARCHING_NODE:
+      message = 'Selecting node backend...';
+      break;
+    case apiGateStates.NODE_AVAILABLE:
+      message = 'Node found';
+      break;
+    case apiGateStates.ERROR_NO_NODE:
+      message = 'Failed to find a node';
+      break;
+    default:
+      console.log(`Unhandled gateState ${gateState}!`);
+  }
 
   if (api) {
     return (
@@ -56,7 +123,7 @@ const NodeApiGate = (props: React.PropsWithChildren<unknown>) => {
     // TODO: waiting screen etc.
     return (
       <View>
-        <Text>Waiting for API</Text>
+        <Text>Gatestate: {message}</Text>
       </View>
     );
   }

--- a/BrightID/src/components/NodeApiGateScreen.tsx
+++ b/BrightID/src/components/NodeApiGateScreen.tsx
@@ -14,6 +14,7 @@ export const NodeApiGateScreen = ({
   switch (gateState) {
     case ApiGateState.INITIAL:
     case ApiGateState.SEARCHING_NODE:
+    case ApiGateState.SEARCH_REQUESTED:
       message = 'Selecting node backend...';
       break;
     case ApiGateState.NODE_AVAILABLE:

--- a/BrightID/src/components/NodeApiGateScreen.tsx
+++ b/BrightID/src/components/NodeApiGateScreen.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { ApiGateState } from '@/components/NodeApiGate';
+
+export const NodeApiGateScreen = ({
+  gateState,
+  retryHandler,
+}: {
+  gateState: ApiGateState;
+  retryHandler: () => any;
+}) => {
+  let message: string;
+  let retryInfo;
+  switch (gateState) {
+    case ApiGateState.INITIAL:
+    case ApiGateState.SEARCHING_NODE:
+      message = 'Selecting node backend...';
+      break;
+    case ApiGateState.NODE_AVAILABLE:
+      message = 'Node found';
+      break;
+    case ApiGateState.ERROR_NO_NODE:
+      message = 'Failed to find a node';
+      retryInfo = (
+        <TouchableOpacity onPress={retryHandler}>
+          <Text>Retry</Text>
+        </TouchableOpacity>
+      );
+      break;
+    default:
+      console.log(`Unhandled gateState ${gateState}!`);
+  }
+
+  return (
+    <View>
+      <Text>Gatestate: {message}</Text>
+      {retryInfo || null}
+    </View>
+  );
+};

--- a/BrightID/src/components/NodeApiGateScreen.tsx
+++ b/BrightID/src/components/NodeApiGateScreen.tsx
@@ -1,41 +1,177 @@
-import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  Image,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { ApiGateState } from '@/components/NodeApiGate';
+import { BLACK, ORANGE, RED, WHITE } from '@/theme/colors';
+import { DEVICE_LARGE } from '@/utils/deviceConstants';
+import { fontSize } from '@/theme/fonts';
+import { useTranslation } from 'react-i18next';
+import Spinner from 'react-native-spinkit';
+import IonIcons from 'react-native-vector-icons/Ionicons';
 
 export const NodeApiGateScreen = ({
   gateState,
+  startTimestamp,
   retryHandler,
 }: {
   gateState: ApiGateState;
+  startTimestamp: number;
   retryHandler: () => any;
 }) => {
-  let message: string;
-  let retryInfo;
-  switch (gateState) {
-    case ApiGateState.INITIAL:
-    case ApiGateState.SEARCHING_NODE:
-    case ApiGateState.SEARCH_REQUESTED:
-      message = 'Selecting node backend...';
-      break;
-    case ApiGateState.NODE_AVAILABLE:
-      message = 'Node found';
-      break;
-    case ApiGateState.ERROR_NO_NODE:
-      message = 'Failed to find a node';
-      retryInfo = (
-        <TouchableOpacity onPress={retryHandler}>
-          <Text>Retry</Text>
-        </TouchableOpacity>
-      );
-      break;
-    default:
-      console.log(`Unhandled gateState ${gateState}!`);
-  }
+  const { t } = useTranslation();
+  const [stateDescription, setStateDescription] = useState('');
+  const [iconData, setIconData] = useState<{ color: string; name: string }>(
+    undefined,
+  );
 
-  return (
-    <View>
-      <Text>Gatestate: {message}</Text>
-      {retryInfo || null}
+  useEffect(() => {
+    switch (gateState) {
+      case ApiGateState.INITIAL:
+      case ApiGateState.SEARCHING_NODE:
+      case ApiGateState.SEARCH_REQUESTED:
+        setIconData(undefined);
+        setStateDescription('Connecting to BrightID node...');
+        break;
+      case ApiGateState.NODE_AVAILABLE:
+        setStateDescription('Node found');
+        break;
+      case ApiGateState.ERROR_NO_NODE:
+        setStateDescription(
+          'Failed to connect to a BrightID node. Please check your network connectivity.',
+        );
+        setIconData({ color: RED, name: 'alert-circle-outline' });
+        break;
+      default:
+        console.log(`Unhandled gateState ${gateState}!`);
+    }
+  }, [gateState]);
+
+  const retryInfo = (
+    <View style={styles.retryBtnContainer}>
+      <TouchableOpacity style={styles.retryBtn} onPress={retryHandler}>
+        <Text style={styles.retryBtnText}>Retry</Text>
+      </TouchableOpacity>
     </View>
   );
+
+  return (
+    <>
+      <SafeAreaView style={styles.container}>
+        <StatusBar
+          barStyle="dark-content"
+          backgroundColor={WHITE}
+          animated={true}
+        />
+
+        <View style={styles.header}>
+          <Image
+            source={require('@/static/brightid-final.png')}
+            accessible={true}
+            accessibilityLabel="Home Header Logo"
+            resizeMode="contain"
+            style={styles.logo}
+          />
+        </View>
+        <View style={styles.center}>
+          {iconData ? (
+            <IonIcons
+              style={{ alignSelf: 'center' }}
+              size={DEVICE_LARGE ? 84 : 72}
+              name={iconData.name}
+              color={iconData.color}
+            />
+          ) : (
+            <Spinner
+              isVisible={true}
+              size={DEVICE_LARGE ? 84 : 72}
+              type="Wave"
+              color={ORANGE}
+            />
+          )}
+          <View style={styles.infoTextContainer}>
+            <Text style={styles.infoText}>{stateDescription}</Text>
+          </View>
+          {gateState === ApiGateState.ERROR_NO_NODE && retryInfo}
+        </View>
+      </SafeAreaView>
+      <View style={styles.orangeBottom} />
+    </>
+  );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: WHITE,
+    alignItems: 'center',
+    flexDirection: 'column',
+    borderBottomLeftRadius: 58,
+    borderBottomRightRadius: 58,
+    marginBottom: DEVICE_LARGE ? 35 : 20,
+    zIndex: 2,
+    overflow: 'hidden',
+  },
+  orangeBottom: {
+    backgroundColor: ORANGE,
+    width: '100%',
+    height: 100,
+    zIndex: 1,
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  header: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: '15%',
+  },
+  logo: {
+    maxWidth: '40%',
+    maxHeight: 90,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoTextContainer: {
+    margin: 40,
+  },
+  infoText: {
+    fontFamily: 'Poppins-Medium',
+    fontSize: fontSize[16],
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  retryBtnContainer: {
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: DEVICE_LARGE ? 85 : 70,
+  },
+  retryBtn: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: DEVICE_LARGE ? 160 : 140,
+    height: DEVICE_LARGE ? 50 : 45,
+    backgroundColor: ORANGE,
+    borderRadius: 100,
+    elevation: 1,
+    shadowColor: BLACK,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 4,
+  },
+  retryBtnText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[16],
+    color: WHITE,
+  },
+});

--- a/BrightID/src/components/Notifications/InviteCard.tsx
+++ b/BrightID/src/components/Notifications/InviteCard.tsx
@@ -18,8 +18,8 @@ import {
   rejectInvite,
   joinGroup,
   selectConnectionById,
+  addOperation,
 } from '@/actions';
-import api from '@/api/brightId';
 import GroupPhoto from '@/components/Groups/GroupPhoto';
 import {
   backupUser,
@@ -29,6 +29,7 @@ import Check from '@/components/Icons/Check';
 import xGrey from '@/static/x_grey.svg';
 import { useNavigation } from '@react-navigation/native';
 import BrightidError from '@/api/brightidError';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
 const InviteCard = (props) => {
   const { invite } = props;
@@ -39,6 +40,7 @@ const InviteCard = (props) => {
   );
   const navigation = useNavigation();
   const { backupCompleted } = useSelector((state: State) => state.user);
+  const api = useSelector(selectNodeApi);
 
   const handleRejectInvite = () => {
     Alert.alert(
@@ -56,7 +58,8 @@ const InviteCard = (props) => {
             try {
               await dispatch(rejectInvite(invite.id));
               if (invite.isNew) {
-                await api.deleteGroup(invite.id);
+                const op = await api.deleteGroup(invite.id);
+                dispatch(addOperation(op));
               }
             } catch (err) {
               Alert.alert(
@@ -73,7 +76,8 @@ const InviteCard = (props) => {
 
   const handleAcceptInvite = async () => {
     try {
-      await api.joinGroup(invite.id);
+      const op = await api.joinGroup(invite.id);
+      dispatch(addOperation(op));
       dispatch(acceptInvite(invite.id));
       await dispatch(joinGroup(invite));
       Alert.alert(

--- a/BrightID/src/components/Notifications/InviteCard.tsx
+++ b/BrightID/src/components/Notifications/InviteCard.tsx
@@ -29,7 +29,8 @@ import Check from '@/components/Icons/Check';
 import xGrey from '@/static/x_grey.svg';
 import { useNavigation } from '@react-navigation/native';
 import BrightidError from '@/api/brightidError';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { useContext } from 'react';
+import { NodeApiContext } from '@/components/NodeApiGate';
 
 const InviteCard = (props) => {
   const { invite } = props;
@@ -40,7 +41,7 @@ const InviteCard = (props) => {
   );
   const navigation = useNavigation();
   const { backupCompleted } = useSelector((state: State) => state.user);
-  const api = useSelector(selectNodeApi);
+  const api = useContext(NodeApiContext);
 
   const handleRejectInvite = () => {
     Alert.alert(

--- a/BrightID/src/components/Notifications/NotificationsScreen.tsx
+++ b/BrightID/src/components/Notifications/NotificationsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import {
   Dimensions,
   StyleSheet,
@@ -30,6 +30,7 @@ import { selectAllUnconfirmedConnections } from '@/components/PendingConnections
 import fetchUserInfo from '@/actions/fetchUserInfo';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { photoDirectory } from '@/utils/filesystem';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import NotificationCard from './NotificationCard';
 import InviteCard from './InviteCard';
 import PendingConnectionCard from './PendingConnectionCard';
@@ -47,10 +48,11 @@ const inviteSelector = createSelector(
 
 const useRefresh: () => [boolean, () => void] = () => {
   const dispatch = useDispatch();
+  const api = useContext(NodeApiContext);
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = () => {
     setRefreshing(true);
-    dispatch(fetchUserInfo())
+    dispatch(fetchUserInfo(api))
       .then(() => {
         setRefreshing(true);
       })
@@ -230,6 +232,7 @@ export const NotificationsScreen = () => {
   const dispatch = useDispatch();
   const route = useRoute<NotificationsRoute>();
   const { t } = useTranslation();
+  const api = useContext(NodeApiContext);
 
   const pendingConnections = useSelector(
     (state) => selectAllUnconfirmedConnections(state)?.length,
@@ -281,8 +284,8 @@ export const NotificationsScreen = () => {
 
   useFocusEffect(
     useCallback(() => {
-      dispatch(fetchUserInfo());
-    }, [dispatch]),
+      dispatch(fetchUserInfo(api));
+    }, [api, dispatch]),
   );
 
   console.log('renderingNotificationScreen');

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionCard.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   Alert,
   Image,
@@ -17,6 +17,7 @@ import { fontSize } from '@/theme/fonts';
 import { ConnectionStatus } from '@/components/Helpers/ConnectionStatus';
 import ChannelAPI from '@/api/channelService';
 import VerifiedBadge from '@/components/Icons/VerifiedBadge';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { uploadSig, uploadMutualInfo } from './thunks/channelUploadThunks';
 import { resetRecoveryData } from './recoveryDataSlice';
 
@@ -34,6 +35,7 @@ const RecoveringConnectionCard = (props) => {
     setUploadingData,
   } = props;
 
+  const nodeApi = useContext(NodeApiContext);
   const [imgErr, setImgErr] = useState(false);
   const aesKey = useSelector((state) => state.recoveryData.aesKey);
   const channel = useSelector((state) => state.recoveryData.channel);
@@ -73,6 +75,7 @@ const RecoveringConnectionCard = (props) => {
           conn: props,
           aesKey,
           channelApi,
+          nodeApi,
         }),
       );
 

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
@@ -14,14 +14,8 @@ import { BLACK, DARKER_GREY, LIGHT_BLACK, ORANGE, WHITE } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { RecoveryErrorType } from '@/components/Onboarding/RecoveryFlow/RecoveryError';
-import {
-  channel_types,
-  closeChannel,
-} from '@/components/PendingConnections/channelSlice';
-import api from '@/api/brightId';
 import { setupRecovery } from '@/components/Onboarding/RecoveryFlow/thunks/recoveryThunks';
 import { buildRecoveryChannelQrUrl } from '@/utils/recovery';
-import { buildChannelQrUrl } from '@/utils/channels';
 import {
   clearChannel,
   createChannel,

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { StyleSheet, View, KeyboardAvoidingView, Alert } from 'react-native';
 import { useDispatch, useSelector } from '@/store';
 import { useFocusEffect } from '@react-navigation/native';
@@ -8,6 +8,7 @@ import { setBackupCompleted, setPassword } from '@/reducer/userSlice';
 import { RecoverAccount } from '@/components/Onboarding/RecoveryFlow/RecoverAccount';
 import { RestoreBackup } from '@/components/Onboarding/RecoveryFlow/RestoreBackup';
 import { useTranslation } from 'react-i18next';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import {
   finishRecovery,
   recoverAccount,
@@ -38,6 +39,7 @@ export enum BackupSteps {
 const RestoreScreen = () => {
   const { t } = useTranslation();
   const [pass, setPass] = useState('');
+  const api = useContext(NodeApiContext);
   const recoveredConnections = useSelector(
     (state) => state.recoveryData.recoveredConnections,
   );
@@ -72,7 +74,7 @@ const RestoreScreen = () => {
     const runEffect = async () => {
       try {
         console.log(`Starting account recovery`);
-        await dispatch(recoverAccount());
+        await dispatch(recoverAccount(api));
         console.log(`Successfully recovered account`);
         setAccountStep(AccountSteps.COMPLETE);
         // restore backup can now start
@@ -90,7 +92,7 @@ const RestoreScreen = () => {
       default:
         break;
     }
-  }, [dispatch, accountStep]);
+  }, [dispatch, accountStep, api]);
 
   // track data recovery state
   useEffect(() => {
@@ -130,7 +132,7 @@ const RestoreScreen = () => {
     try {
       console.log(`Starting restore backup`);
       setDataStep(BackupSteps.RESTORING_DATA);
-      await dispatch(recoverData(pass));
+      await dispatch(recoverData(pass, api));
       console.log(`Successfully restored backup`);
       setDataStep(BackupSteps.COMPLETE);
     } catch (e) {

--- a/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -22,7 +22,7 @@ import {
   addOperation,
 } from '@/actions';
 import { calculateCooldownPeriod } from '@/utils/recovery';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import TrustedConnectionCard from './TrustedConnectionCard';
 
 /**
@@ -49,7 +49,7 @@ const TrustedConnectionsScreen = () => {
     recoveryConnections.map((item) => item.id),
   );
   const [updateInProgress, setUpdateInProgress] = useState(false);
-  const api = useSelector(selectNodeApi);
+  const api = useContext(NodeApiContext);
 
   const knownLevels = Array<ConnectionLevel>(
     connection_levels.ALREADY_KNOWN,

--- a/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/TrustedConnectionsScreen.tsx
@@ -16,9 +16,13 @@ import { fontSize } from '@/theme/fonts';
 import { DEVICE_LARGE, DEVICE_TYPE } from '@/utils/deviceConstants';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { connection_levels } from '@/utils/constants';
-import api from '@/api/brightId';
-import { setConnectionLevel, recoveryConnectionsSelector } from '@/actions';
+import {
+  setConnectionLevel,
+  recoveryConnectionsSelector,
+  addOperation,
+} from '@/actions';
 import { calculateCooldownPeriod } from '@/utils/recovery';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import TrustedConnectionCard from './TrustedConnectionCard';
 
 /**
@@ -45,6 +49,7 @@ const TrustedConnectionsScreen = () => {
     recoveryConnections.map((item) => item.id),
   );
   const [updateInProgress, setUpdateInProgress] = useState(false);
+  const api = useSelector(selectNodeApi);
 
   const knownLevels = Array<ConnectionLevel>(
     connection_levels.ALREADY_KNOWN,
@@ -136,8 +141,10 @@ const TrustedConnectionsScreen = () => {
               }),
             );
           }
-          await Promise.all(promises);
-
+          const ops = await Promise.all(promises);
+          for (const op of ops) {
+            dispatch(addOperation(op));
+          }
           // show info about cooldown period
           if (cooldownPeriod > 0) {
             navigation.navigate('RecoveryCooldownInfo', {

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
@@ -1,7 +1,7 @@
 import { hash } from '@/utils/encoding';
 import ChannelAPI from '@/api/channelService';
 import { RECOVERY_CHANNEL_KEEPALIVE_THRESHOLD } from '@/utils/constants';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { selectBaseUrl } from '@/reducer/settingsSlice';
 import {
   downloadConnections,
   downloadGroups,
@@ -25,8 +25,8 @@ export const createChannel = () => async (
 ) => {
   try {
     const { recoveryData } = getState();
-    const api = selectNodeApi(getState());
-    const url = new URL(`${api.baseUrl}/profile`);
+    const baseUrl = selectBaseUrl(getState());
+    const url = new URL(`${baseUrl}/profile`);
     const channelApi = new ChannelAPI(url.href);
     const channelId = hash(recoveryData.aesKey);
     console.log(`created channel ${channelId} for recovery data`);

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelThunks.ts
@@ -1,7 +1,7 @@
 import { hash } from '@/utils/encoding';
-import api from '@/api/brightId';
 import ChannelAPI from '@/api/channelService';
 import { RECOVERY_CHANNEL_KEEPALIVE_THRESHOLD } from '@/utils/constants';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 import {
   downloadConnections,
   downloadGroups,
@@ -25,7 +25,7 @@ export const createChannel = () => async (
 ) => {
   try {
     const { recoveryData } = getState();
-
+    const api = selectNodeApi(getState());
     const url = new URL(`${api.baseUrl}/profile`);
     const channelApi = new ChannelAPI(url.href);
     const channelId = hash(recoveryData.aesKey);

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
@@ -3,7 +3,6 @@ import nacl from 'tweetnacl';
 import stringify from 'fast-json-stable-stringify';
 import { retrieveImage } from '@/utils/filesystem';
 import { encryptData } from '@/utils/cryptoHelper';
-import api from '@/api/brightId';
 import { strToUint8Array, uInt8ArrayToB64, hash } from '@/utils/encoding';
 import { selectAllConnections } from '@/reducer/connectionsSlice';
 import { loadRecoveryData } from './channelDownloadThunks';

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
@@ -111,10 +111,12 @@ const uploadGroup = async ({ group, channelApi, aesKey }) => {
   }
 };
 
-export const uploadMutualInfo = ({ conn, aesKey, channelApi }) => async (
-  dispatch,
-  getState,
-) => {
+export const uploadMutualInfo = ({
+  conn,
+  aesKey,
+  channelApi,
+  nodeApi,
+}) => async (dispatch, getState) => {
   try {
     const dataIds = await channelApi.list(hash(aesKey));
     if (!dataIds.includes(`connection_${conn.id}`)) {
@@ -130,7 +132,10 @@ export const uploadMutualInfo = ({ conn, aesKey, channelApi }) => async (
     connections = _.keyBy(connections, 'id');
     groups = _.keyBy(groups, 'id');
 
-    const otherSideConnections = await api.getConnections(conn.id, 'inbound');
+    const otherSideConnections = await nodeApi.getConnections(
+      conn.id,
+      'inbound',
+    );
     const knownLevels = ['just met', 'already known', 'recovery'];
     const mutualConnections = otherSideConnections
       ? otherSideConnections
@@ -148,7 +153,7 @@ export const uploadMutualInfo = ({ conn, aesKey, channelApi }) => async (
       mutualConnections.push(user);
     }
 
-    const otherSideGroups = await api.getUserInfo(conn.id)?.groups;
+    const otherSideGroups = await nodeApi.getUserInfo(conn.id)?.groups;
     const mutualGroups = otherSideGroups
       ? otherSideGroups.filter((g) => groups[g.id]).map((g) => groups[g.id])
       : [];

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test.ts
@@ -23,10 +23,13 @@ const mockStore = configureStore(
 
 // we use `recoveryData` throughout these tests instead of relying on redux
 const recoveryData = initialState;
+const settings = {
+  baseUrl: new URL('http://test.brightid.org'),
+};
 
 describe('Test recovery data', () => {
   test(`setup recovery data`, async () => {
-    const store = mockStore({ recoveryData });
+    const store = mockStore({ recoveryData, settings });
 
     const expectedAction = expect.objectContaining({
       type: 'recoveryData/init',
@@ -59,7 +62,7 @@ describe('Test recovery data', () => {
   test('create channel', async () => {
     // update timeout for this test
     jest.setTimeout(10000);
-    const store = mockStore({ recoveryData });
+    const store = mockStore({ recoveryData, settings });
 
     const expectedAction = expect.objectContaining({
       type: 'recoveryData/setRecoveryChannel',

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
@@ -10,7 +10,7 @@ import {
   addOperation,
 } from '@/actions';
 import { OPERATION_APPLIED_BEFORE } from '@/api/brightidError';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApi } from '@/api/brightId';
 import { fetchBackupData } from './backupThunks';
 import {
   init,
@@ -43,12 +43,11 @@ export const setupRecovery = () => async (
   }
 };
 
-export const setSigningKey = () => async (
+export const setSigningKey = (api: NodeApi) => async (
   dispatch: dispatch,
   getState: getState,
 ) => {
   const { recoveryData } = getState();
-  const api = selectNodeApi(getState());
   const sigs = Object.values(recoveryData.sigs);
   console.log('setting signing key');
   try {
@@ -102,22 +101,21 @@ export const restoreUserData = async (id: string, pass: string) => {
   return { userData, connections, groups };
 };
 
-export const recoverAccount = () => async (
+export const recoverAccount = (api: NodeApi) => async (
   dispatch: dispatch,
   getState: getState,
 ) => {
   // set new signing key on the backend
-  await dispatch(setSigningKey());
+  await dispatch(setSigningKey(api));
   const { publicKey, secretKey } = getState().recoveryData;
   dispatch(setKeypair({ publicKey, secretKey }));
 };
 
-export const recoverData = (pass: string) => async (
+export const recoverData = (pass: string, api: NodeApi) => async (
   dispatch: dispatch,
   getState: getState,
 ) => {
   const { id } = getState().recoveryData;
-  const api = selectNodeApi(getState());
   console.log(`Starting recoverData for ${id}`);
   // throws if data is bad
   const restoredData = await restoreUserData(id, pass);

--- a/BrightID/src/components/PendingConnections/MyCodeScreen.tsx
+++ b/BrightID/src/components/PendingConnections/MyCodeScreen.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useState,
@@ -38,6 +39,7 @@ import {
 
 import { createChannel } from '@/components/PendingConnections/actions/channelThunks';
 import { setActiveNotification } from '@/actions';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { QrCode } from './QrCode';
 
 /**
@@ -75,6 +77,7 @@ export const MyCodeScreen = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const api = useContext(NodeApiContext);
 
   const [channelErr, setChannelErr] = useState(0);
 
@@ -121,7 +124,7 @@ export const MyCodeScreen = () => {
         channelErr < 3
       ) {
         InteractionManager.runAfterInteractions(() => {
-          dispatch(createChannel(displayChannelType)).catch((err) => {
+          dispatch(createChannel(displayChannelType, api)).catch((err) => {
             console.log(`error creating channel: ${err.message}`);
             if (channelErr === 2) {
               Alert.alert(
@@ -136,7 +139,15 @@ export const MyCodeScreen = () => {
         });
       }
       dispatch(setActiveNotification(null));
-    }, [navigation, myChannel, dispatch, displayChannelType, channelErr, t]),
+    }, [
+      navigation,
+      myChannel,
+      channelErr,
+      dispatch,
+      displayChannelType,
+      api,
+      t,
+    ]),
   );
 
   // Navigate to next screen if QRCode has been scanned

--- a/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
+++ b/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from '@/store';
 import { InteractionManager, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { WHITE } from '@/theme/colors';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { confirmPendingConnectionThunk } from './actions/pendingConnectionThunks';
 import {
   pendingConnection_states,
@@ -20,7 +21,7 @@ type PreviewConnectionProps = {
 export const PreviewConnectionController = (props: PreviewConnectionProps) => {
   const { pendingConnectionId, moveToNext } = props;
   const dispatch = useDispatch();
-
+  const api = useContext(NodeApiContext);
   const pendingConnection = useSelector((state: State) =>
     selectPendingConnectionById(state, pendingConnectionId),
   ) as PendingConnection;
@@ -44,7 +45,7 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
     moveToNext();
     // wait until after finishes navigation before dispatching confirm action
     InteractionManager.runAfterInteractions(() => {
-      dispatch(confirmPendingConnectionThunk(pendingConnection.id, level));
+      dispatch(confirmPendingConnectionThunk(pendingConnection.id, level, api));
     });
   };
 

--- a/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
+++ b/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useContext } from 'react';
 import {
   Linking,
   StyleSheet,
@@ -33,6 +33,7 @@ import i18next from 'i18next';
 import { BarCodeReadEvent } from 'react-native-camera';
 import { hash } from '@/utils/encoding';
 import { qrCodeURL_types } from '@/utils/constants';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { RNCamera } from './RNCameraProvider';
 import {
   setAesKey,
@@ -72,6 +73,7 @@ export const ScanCodeScreen = () => {
   const [qrData, setQrData] = useState(undefined);
   const name = useSelector((state: State) => state.user.name);
   const { t } = useTranslation();
+  const api = useContext(NodeApiContext);
 
   const pendingConnectionSizeForChannel = useSelector((state: State) => {
     if (channel) {
@@ -162,7 +164,7 @@ export const ScanCodeScreen = () => {
               );
               const channel = await parseChannelQrURL(channelURL);
               setChannel(channel);
-              await dispatch(joinChannel(channel));
+              await dispatch(joinChannel(channel, api));
               break;
             }
           }
@@ -183,7 +185,7 @@ export const ScanCodeScreen = () => {
     if (qrData) {
       handleQrData(qrData);
     }
-  }, [dispatch, navigation, qrData]);
+  }, [api, dispatch, navigation, qrData]);
 
   const handleBarCodeRead = ({ data }: BarCodeReadEvent) => {
     console.log(`Scanned QRCode: ${data}`);

--- a/BrightID/src/components/PendingConnections/actions/channelThunks.ts
+++ b/BrightID/src/components/PendingConnections/actions/channelThunks.ts
@@ -1,4 +1,3 @@
-import api from '@/api/brightId';
 import {
   addChannel,
   selectChannelById,
@@ -24,12 +23,15 @@ import {
   newPendingConnection,
   selectAllPendingConnectionIds,
 } from '@/components/PendingConnections/pendingConnectionSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
 export const createChannel = (channelType: ChannelType) => async (
   dispatch: dispatch,
+  getState,
 ) => {
   let channel: Channel | null | undefined;
   try {
+    const api = selectNodeApi(getState());
     const url = new URL(`${api.baseUrl}/profile`);
     channel = await generateChannelData(channelType, url);
 

--- a/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
+++ b/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
@@ -15,13 +15,13 @@ import {
   updatePendingConnection,
 } from '@/components/PendingConnections/pendingConnectionSlice';
 import { leaveChannel } from '@/components/PendingConnections/actions/channelThunks';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApi } from '@/api/brightId';
 
 export const confirmPendingConnectionThunk = (
   id: string,
   level: ConnectionLevel,
+  api: NodeApi,
 ) => async (dispatch: dispatch, getState: getState) => {
-  const api = selectNodeApi(getState());
   const connection: PendingConnection = selectPendingConnectionById(
     getState(),
     id,

--- a/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
+++ b/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
@@ -11,11 +11,12 @@ import {
 } from '@/components/PendingConnections/channelSlice';
 import { selectConnectionById } from '@/reducer/connectionsSlice';
 import { decryptData } from '@/utils/cryptoHelper';
-import api from '@/api/brightId';
 import { Alert } from 'react-native';
 import { PROFILE_VERSION } from '@/utils/constants';
 import { createDeepEqualStringArraySelector } from '@/utils/createDeepEqualStringArraySelector';
 import BrightidError, { USER_NOT_FOUND } from '@/api/brightidError';
+import { useSelector } from '@/store';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
 const pendingConnectionsAdapter = createEntityAdapter<PendingConnection>();
 
@@ -53,6 +54,7 @@ export const newPendingConnection = createAsyncThunk<
   'pendingConnections/newPendingConnection',
   async ({ channelId, profileId }, { getState }) => {
     console.log(`new pending connection ${profileId} in channel ${channelId}`);
+    const api = selectNodeApi(getState());
 
     const channel = selectChannelById(getState(), channelId);
 

--- a/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
+++ b/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
@@ -15,8 +15,7 @@ import { Alert } from 'react-native';
 import { PROFILE_VERSION } from '@/utils/constants';
 import { createDeepEqualStringArraySelector } from '@/utils/createDeepEqualStringArraySelector';
 import BrightidError, { USER_NOT_FOUND } from '@/api/brightidError';
-import { useSelector } from '@/store';
-import { selectNodeApi } from '@/reducer/settingsSlice';
+import { NodeApi } from '@/api/brightId';
 
 const pendingConnectionsAdapter = createEntityAdapter<PendingConnection>();
 
@@ -45,16 +44,15 @@ export enum pendingConnection_states {
 
 export const newPendingConnection = createAsyncThunk<
   PendingConnection,
-  { channelId: string; profileId: string },
+  { channelId: string; profileId: string; api: NodeApi },
   {
     dispatch: Dispatch;
     state: State;
   }
 >(
   'pendingConnections/newPendingConnection',
-  async ({ channelId, profileId }, { getState }) => {
+  async ({ channelId, profileId, api }, { getState }) => {
     console.log(`new pending connection ${profileId} in channel ${channelId}`);
-    const api = selectNodeApi(getState());
 
     const channel = selectChannelById(getState(), channelId);
 

--- a/BrightID/src/reducer/index.ts
+++ b/BrightID/src/reducer/index.ts
@@ -11,6 +11,7 @@ import tasks from '../components/Tasks/TasksSlice';
 import socialMedia from '../components/EditProfile/socialMediaSlice';
 import recoveryData from '../components/Onboarding/RecoveryFlow/recoveryDataSlice';
 import walkthrough from './walkthroughSlice';
+import settings from './settingsSlice';
 
 export default {
   apps,
@@ -26,4 +27,5 @@ export default {
   tasks,
   socialMedia,
   walkthrough,
+  settings,
 };

--- a/BrightID/src/reducer/settingsSlice.ts
+++ b/BrightID/src/reducer/settingsSlice.ts
@@ -1,16 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-let seedUrl = 'http://node.brightid.org';
-if (__DEV__) {
-  seedUrl = 'http://test.brightid.org';
-}
-
 interface SettingsSlice {
-  baseUrl: string;
+  baseUrl: string | null;
 }
 
 const initialState: SettingsSlice = {
-  baseUrl: seedUrl,
+  baseUrl: null,
 };
 
 export const settingsSlice = createSlice({
@@ -20,13 +15,20 @@ export const settingsSlice = createSlice({
     setBaseUrl: (state, action: PayloadAction<string>) => {
       state.baseUrl = action.payload;
     },
+    clearBaseUrl: (state) => {
+      state.baseUrl = null;
+    },
     resetSettings: (state) => {
       state = initialState;
     },
   },
 });
 
-export const { setBaseUrl, resetSettings } = settingsSlice.actions;
+export const {
+  setBaseUrl,
+  clearBaseUrl,
+  resetSettings,
+} = settingsSlice.actions;
 
 export const selectBaseUrl = (state: State) => {
   return state.settings.baseUrl;

--- a/BrightID/src/reducer/settingsSlice.ts
+++ b/BrightID/src/reducer/settingsSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { NodeApi } from '@/api/brightId';
 
 let seedUrl = 'http://node.brightid.org';
 if (__DEV__) {
@@ -8,12 +7,10 @@ if (__DEV__) {
 
 interface SettingsSlice {
   baseUrl: string;
-  api: NodeApi | undefined;
 }
 
 const initialState: SettingsSlice = {
   baseUrl: seedUrl,
-  api: undefined,
 };
 
 export const settingsSlice = createSlice({
@@ -23,55 +20,16 @@ export const settingsSlice = createSlice({
     setBaseUrl: (state, action: PayloadAction<string>) => {
       state.baseUrl = action.payload;
     },
-    setApiInstance: (state, action: PayloadAction<NodeApi>) => {
-      state.api = action.payload;
-    },
     resetSettings: (state) => {
       state = initialState;
     },
   },
 });
 
-export const {
-  setBaseUrl,
-  resetSettings,
-  setApiInstance,
-} = settingsSlice.actions;
+export const { setBaseUrl, resetSettings } = settingsSlice.actions;
 
 export const selectBaseUrl = (state: State) => {
   return state.settings.baseUrl;
-};
-export const selectNodeApi = (state: State) => {
-  return state.settings.api;
-};
-
-export const setBaseUrlThunk = (newBaseUrl: string) => async (
-  dispatch,
-  getState,
-) => {
-  try {
-    // TODO: Check if url is actually working
-
-    const api = selectNodeApi(getState);
-    if (api) {
-      api.baseUrl = newBaseUrl;
-    }
-    dispatch(setBaseUrl(newBaseUrl));
-  } catch (e) {
-    console.log(`Failed to set baseUrl ${newBaseUrl}: ${e.message}`);
-  }
-};
-
-export const initApiThunk = () => async (dispatch, getState) => {
-  const { id } = getState().user;
-  const { secretKey } = getState().keypair;
-  const url = getState().settings.baseUrl;
-  try {
-    const apiInstance = new NodeApi({ url, id, secretKey });
-    dispatch(setApiInstance(apiInstance));
-  } catch (e) {
-    console.log(`Failed to initialize API: ${e.message}`);
-  }
 };
 
 export default settingsSlice.reducer;

--- a/BrightID/src/reducer/settingsSlice.ts
+++ b/BrightID/src/reducer/settingsSlice.ts
@@ -1,0 +1,77 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { NodeApi } from '@/api/brightId';
+
+let seedUrl = 'http://node.brightid.org';
+if (__DEV__) {
+  seedUrl = 'http://test.brightid.org';
+}
+
+interface SettingsSlice {
+  baseUrl: URL;
+  api: NodeApi | undefined;
+}
+
+const initialState: SettingsSlice = {
+  baseUrl: new URL(seedUrl),
+  api: undefined,
+};
+
+export const settingsSlice = createSlice({
+  name: 'settings',
+  initialState,
+  reducers: {
+    setBaseUrl: (state, action: PayloadAction<URL>) => {
+      state.baseUrl = action.payload;
+    },
+    setApiInstance: (state, action: PayloadAction<NodeApi>) => {
+      state.api = action.payload;
+    },
+    resetSettings: (state) => {
+      state = initialState;
+    },
+  },
+});
+
+export const {
+  setBaseUrl,
+  resetSettings,
+  setApiInstance,
+} = settingsSlice.actions;
+
+export const selectBaseUrl = (state: State) => {
+  return state.settings.baseUrl;
+};
+export const selectNodeApi = (state: State) => {
+  return state.settings.api;
+};
+
+export const setBaseUrlThunk = (newBaseUrl: URL) => async (
+  dispatch,
+  getState,
+) => {
+  try {
+    // TODO: Check if url is actually working
+
+    const api = selectNodeApi(getState);
+    if (api) {
+      api.baseUrl = newBaseUrl.href;
+    }
+    dispatch(setBaseUrl(newBaseUrl));
+  } catch (e) {
+    console.log(`Failed to set baseUrl ${newBaseUrl.href}: ${e.message}`);
+  }
+};
+
+export const initApiThunk = () => async (dispatch, getState) => {
+  const { id } = getState().user;
+  const { secretKey } = getState().keypair;
+  const url = getState().settings.baseUrl;
+  try {
+    const apiInstance = new NodeApi({ url, id, secretKey });
+    dispatch(setApiInstance(apiInstance));
+  } catch (e) {
+    console.log(`Failed to initialize API: ${e.message}`);
+  }
+};
+
+export default settingsSlice.reducer;

--- a/BrightID/src/reducer/settingsSlice.ts
+++ b/BrightID/src/reducer/settingsSlice.ts
@@ -7,12 +7,12 @@ if (__DEV__) {
 }
 
 interface SettingsSlice {
-  baseUrl: URL;
+  baseUrl: string;
   api: NodeApi | undefined;
 }
 
 const initialState: SettingsSlice = {
-  baseUrl: new URL(seedUrl),
+  baseUrl: seedUrl,
   api: undefined,
 };
 
@@ -20,7 +20,7 @@ export const settingsSlice = createSlice({
   name: 'settings',
   initialState,
   reducers: {
-    setBaseUrl: (state, action: PayloadAction<URL>) => {
+    setBaseUrl: (state, action: PayloadAction<string>) => {
       state.baseUrl = action.payload;
     },
     setApiInstance: (state, action: PayloadAction<NodeApi>) => {
@@ -45,7 +45,7 @@ export const selectNodeApi = (state: State) => {
   return state.settings.api;
 };
 
-export const setBaseUrlThunk = (newBaseUrl: URL) => async (
+export const setBaseUrlThunk = (newBaseUrl: string) => async (
   dispatch,
   getState,
 ) => {
@@ -54,11 +54,11 @@ export const setBaseUrlThunk = (newBaseUrl: URL) => async (
 
     const api = selectNodeApi(getState);
     if (api) {
-      api.baseUrl = newBaseUrl.href;
+      api.baseUrl = newBaseUrl;
     }
     dispatch(setBaseUrl(newBaseUrl));
   } catch (e) {
-    console.log(`Failed to set baseUrl ${newBaseUrl.href}: ${e.message}`);
+    console.log(`Failed to set baseUrl ${newBaseUrl}: ${e.message}`);
   }
 };
 

--- a/BrightID/src/reducer/types.d.ts
+++ b/BrightID/src/reducer/types.d.ts
@@ -1,6 +1,7 @@
 /**
  * Apps
  */
+import { NodeApi } from '@/api/brightId';
 
 type AppsState = {
   apps: AppInfo[];
@@ -86,3 +87,11 @@ type OperationsState = EntityState<NodeOps>;
 /**
  * WalkthroughSlice
  */
+
+/**
+ * SettingsSlice
+ */
+type SettingsState = {
+  baseUrl: string;
+  api: NodeApi | undefined;
+};

--- a/BrightID/src/routes/index.tsx
+++ b/BrightID/src/routes/index.tsx
@@ -19,18 +19,16 @@ const Stack = createStackNavigator();
 
 const MainTabs = () => {
   return (
-    <NodeApiGate>
-      <Stack.Navigator headerMode="screen">
-        {Home()}
-        {PendingConnections()}
-        {Connections()}
-        {Groups()}
-        {Notifications()}
-        {Apps()}
-        {Modals()}
-        {Backup()}
-      </Stack.Navigator>
-    </NodeApiGate>
+    <Stack.Navigator headerMode="screen">
+      {Home()}
+      {PendingConnections()}
+      {Connections()}
+      {Groups()}
+      {Notifications()}
+      {Apps()}
+      {Modals()}
+      {Backup()}
+    </Stack.Navigator>
   );
 };
 
@@ -38,27 +36,29 @@ const MainApp = () => {
   const id = useSelector((state: State) => state.user.id);
   const eula = useSelector((state: State) => state.user.eula);
   return (
-    <TopStack.Navigator>
-      {!eula ? (
-        <TopStack.Screen
-          name="Eula"
-          component={Eula}
-          options={{ headerShown: false }}
-        />
-      ) : !id ? (
-        <TopStack.Screen
-          name="Onboarding"
-          component={Onboarding}
-          options={{ headerShown: false }}
-        />
-      ) : (
-        <TopStack.Screen
-          name="App"
-          component={MainTabs}
-          options={{ headerShown: false }}
-        />
-      )}
-    </TopStack.Navigator>
+    <NodeApiGate>
+      <TopStack.Navigator>
+        {!eula ? (
+          <TopStack.Screen
+            name="Eula"
+            component={Eula}
+            options={{ headerShown: false }}
+          />
+        ) : !id ? (
+          <TopStack.Screen
+            name="Onboarding"
+            component={Onboarding}
+            options={{ headerShown: false }}
+          />
+        ) : (
+          <TopStack.Screen
+            name="App"
+            component={MainTabs}
+            options={{ headerShown: false }}
+          />
+        )}
+      </TopStack.Navigator>
+    </NodeApiGate>
   );
 };
 

--- a/BrightID/src/routes/index.tsx
+++ b/BrightID/src/routes/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import { useSelector } from '@/store';
+import NodeApiGate from '@/components/NodeApiGate';
+import { PersistGate } from 'redux-persist/es/integration/react';
 import Apps from './Apps';
 import Backup from './Backup';
 import Connections from './Connections';
@@ -17,16 +19,18 @@ const Stack = createStackNavigator();
 
 const MainTabs = () => {
   return (
-    <Stack.Navigator headerMode="screen">
-      {Home()}
-      {PendingConnections()}
-      {Connections()}
-      {Groups()}
-      {Notifications()}
-      {Apps()}
-      {Modals()}
-      {Backup()}
-    </Stack.Navigator>
+    <NodeApiGate>
+      <Stack.Navigator headerMode="screen">
+        {Home()}
+        {PendingConnections()}
+        {Connections()}
+        {Groups()}
+        {Notifications()}
+        {Apps()}
+        {Modals()}
+        {Backup()}
+      </Stack.Navigator>
+    </NodeApiGate>
   );
 };
 

--- a/BrightID/src/store/index.ts
+++ b/BrightID/src/store/index.ts
@@ -69,7 +69,7 @@ const socialMediaPersistConfig = {
 const settingsPersistConfig = {
   ...fsPersistConfig,
   key: 'settings',
-  blacklist: ['api'],
+  blacklist: ['baseUrl'],
 };
 
 const keypairPersistConfig = {

--- a/BrightID/src/store/index.ts
+++ b/BrightID/src/store/index.ts
@@ -66,6 +66,12 @@ const socialMediaPersistConfig = {
   key: 'socialMedia',
 };
 
+const settingsPersistConfig = {
+  ...fsPersistConfig,
+  key: 'settings',
+  blacklist: ['api'],
+};
+
 const keypairPersistConfig = {
   key: 'keypair',
   storage: KeychainStorage,
@@ -90,6 +96,7 @@ const rootReducer = combineReducers({
   socialMedia: persistReducer(socialMediaPersistConfig, reducers.socialMedia),
   tasks: persistReducer(tasksPersistConfig, reducers.tasks),
   user: persistReducer(userPersistConfig, reducers.user),
+  settings: persistReducer(settingsPersistConfig, reducers.settings),
 });
 
 export const store = configureStore({

--- a/BrightID/src/utils/connectionTestButton.tsx
+++ b/BrightID/src/utils/connectionTestButton.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { TouchableOpacity } from 'react-native';
 import Material from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useDispatch } from '@/store';
 import { BLUE, WHITE } from '@/theme/colors';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import {
   connectWithOtherFakeConnections,
   joinAllGroups,
@@ -24,16 +25,17 @@ const btnOptions = [
 const ConnectionTestButton = ({ connectionId }: { connectionId: string }) => {
   const { showActionSheetWithOptions } = useActionSheet();
   const dispatch = useDispatch();
+  const api = useContext(NodeApiContext);
 
   const performAction = (index: number) => {
     switch (index) {
       case 0:
         console.log(`Joining all groups`);
-        dispatch(joinAllGroups(connectionId));
+        dispatch(joinAllGroups(connectionId, api));
         break;
       case 1:
         console.log(`Connecting to other fake connections`);
-        dispatch(connectWithOtherFakeConnections(connectionId));
+        dispatch(connectWithOtherFakeConnections(connectionId, api));
         break;
       case 2:
         console.log(`Reconnecting with different profile`);

--- a/BrightID/src/utils/constants.ts
+++ b/BrightID/src/utils/constants.ts
@@ -24,6 +24,9 @@ export const ORANGE = '#ED7A5D';
 export const LIGHTBLUE = '#4A90E2';
 export const DARK_ORANGE = '#B64B32';
 
+/** Nodechooser constants * */
+export const NODE_CHOOSER_TIMEOUT_MS = 10 * 1000; // Fail if no valid node found within timeout
+
 /** ** NOTIFICATION CONSTANTS  *** */
 export const CONNECTIONS_TYPE = 'connections';
 export const GROUPS_TYPE = 'groups';

--- a/BrightID/src/utils/fakeHelper.ts
+++ b/BrightID/src/utils/fakeHelper.ts
@@ -1,9 +1,10 @@
-import api from '@/api/brightId';
+import { NodeApi } from '@/api/brightId';
 import { connection_levels } from './constants';
 
 export const connectFakeUsers = async (
   fakeUser1: FakeUser,
   fakeUser2: FakeUser,
+  api: NodeApi,
 ) => {
   const timestamp = Date.now();
 
@@ -30,5 +31,6 @@ export const connectFakeUsers = async (
     fakeUser2,
   );
 
-  await Promise.all([user1Promise, user2Promise]);
+  const ops = await Promise.all([user1Promise, user2Promise]);
+  return ops;
 };

--- a/BrightID/src/utils/nodeChooser.ts
+++ b/BrightID/src/utils/nodeChooser.ts
@@ -1,9 +1,8 @@
 // Shim Promise.any() which is not yet available in react native
 import any from 'promise.any';
+import { NODE_CHOOSER_TIMEOUT_MS } from '@/utils/constants';
 
 any.shim();
-
-const TIMEOUT_MS = 10 * 1000; // Fail if no valid node found within timeout
 
 /**
  * Returns a promise that
@@ -17,7 +16,7 @@ const chooseNode = async (nodeUrls: Array<string>) => {
   // add timeout promise to limit waiting time
   promises.push(
     new Promise((resolve) => {
-      setTimeout(resolve, TIMEOUT_MS, 'TIMEOUT');
+      setTimeout(resolve, NODE_CHOOSER_TIMEOUT_MS, 'TIMEOUT');
     }),
   );
 

--- a/BrightID/src/utils/nodeChooser.ts
+++ b/BrightID/src/utils/nodeChooser.ts
@@ -1,0 +1,127 @@
+// Shim Promise.any() which is not yet available in react native
+import any from 'promise.any';
+
+any.shim();
+
+const TIMEOUT_MS = 10 * 1000; // Fail if no valid node found within timeout
+
+/**
+ * Returns a promise that
+ *  -> Resolves with the baseUrl that is providing the fastest response
+ *  -> Rejects if no url is providing a valid answer in time
+ * @param nodeUrls String array of baseUrls
+ */
+const chooseNode = async (nodeUrls: Array<string>) => {
+  const promises: Array<Promise<string>> = [];
+
+  // add timeout promise to limit waiting time
+  promises.push(
+    new Promise((resolve) => {
+      setTimeout(resolve, TIMEOUT_MS, 'TIMEOUT');
+    }),
+  );
+
+  // create promise for each candidate
+  for (const baseUrl of nodeUrls) {
+    promises.push(validateNode(baseUrl));
+  }
+
+  // Wait for the first promise to resolve with Promise.any()
+  // @ts-ignore: Property 'any' does not exist on type 'PromiseConstructor'
+  const winner: string = await Promise.any(promises);
+
+  return new Promise<string>((resolve, reject) => {
+    if (winner === 'TIMEOUT') {
+      // no node responded within my time limit
+      return reject(new Error('No node responded in time'));
+    } else {
+      console.log(`Nodechooser: Fastest node is ${winner}.`);
+      return resolve(winner);
+    }
+  });
+};
+
+/*
+  Check if the provided Url points to a working BrightID node.
+  Get the response from /brightid/v5/state endpoint and check if the reply
+  makes sense.
+  TODO: Extend this to also check if the profile service is working
+ */
+const validateNode = (baseUrl: string) =>
+  new Promise<string>((resolve, reject) => {
+    const start = Date.now();
+    fetch(`${baseUrl}/brightid/v5/state`)
+      .then((response) => {
+        // network request was okay, now check server response on http level
+        if (!response.ok) {
+          console.log(
+            `Nodechooser: Invalid http response from ${baseUrl}: ${response.status} ${response.statusText}`,
+          );
+          reject(new Error('Response not ok'));
+        } else {
+          // Response is fine on http level. Now see if the content is also fine.
+          return response.json(); // will throw if response body is not JSON
+        }
+      })
+      .then((json) => {
+        // Body contains JSON. Now check if JSON content is acceptable.
+        if (validateJsonResponse(json)) {
+          const elapsed = Date.now() - start;
+          console.log(
+            `Nodechooser: Node ${baseUrl} passed all tests after ${elapsed}ms`,
+          );
+          resolve(baseUrl);
+        } else {
+          console.log(
+            `Nodechooser: Node ${baseUrl} provided unexpected JSON data`,
+          );
+          reject(new Error('JSON response not valid'));
+        }
+      })
+      .catch((error) => {
+        const elapsed = Date.now() - start;
+        console.log(`Nodechooser: Node ${baseUrl} failed after ${elapsed}ms.`);
+        reject(error);
+      });
+  });
+
+/**
+ * Check if json contains expected content.
+ *
+ * Expected schema:
+ * {
+ *   "data": {
+ *     "lastProcessedBlock": number,
+ *     "verificationsBlock": number,
+ *     "initOp": number,
+ *     "sentOp": number,
+ *     "verificationsHashes": object
+ *   }
+ * }
+ *
+ * @param json
+ */
+const expectedRootKey = 'data';
+const expectedBodyKeys = [
+  'lastProcessedBlock',
+  'verificationsBlock',
+  'initOp',
+  'sentOp',
+  'verificationsHashes',
+];
+
+const validateJsonResponse = (json) => {
+  const body = json[expectedRootKey];
+  if (!body) {
+    throw new Error(`Missing rootkey ${expectedRootKey}`);
+  }
+  const keys = Object.keys(body);
+  for (const key of expectedBodyKeys) {
+    if (keys.indexOf(key) === -1) {
+      throw new Error(`Missing bodykey ${key}`);
+    }
+  }
+  return true;
+};
+
+export default chooseNode;

--- a/BrightID/src/utils/operations.js
+++ b/BrightID/src/utils/operations.js
@@ -82,7 +82,7 @@ export const pollOperations = async (api) => {
       }
     }
     if (shouldUpdateLocalState) {
-      store.dispatch(fetchUserInfo());
+      store.dispatch(fetchUserInfo(api));
       store.dispatch(checkTasks());
     }
   } catch (err) {

--- a/BrightID/src/utils/operations.js
+++ b/BrightID/src/utils/operations.js
@@ -9,7 +9,6 @@ import {
 import fetchUserInfo from '@/actions/fetchUserInfo';
 import i18next from 'i18next';
 import { checkTasks } from '@/components/Tasks/TasksSlice';
-import { selectNodeApi } from '@/reducer/settingsSlice';
 
 const time_fudge = 2 * 60 * 1000; // trace operations for 2 minutes
 
@@ -46,9 +45,8 @@ const handleOpUpdate = (store, op, state, result) => {
   }
 };
 
-export const pollOperations = async () => {
+export const pollOperations = async (api) => {
   const operations = selectAllOperations(store.getState());
-  const api = selectNodeApi(store.getState());
 
   let shouldUpdateLocalState = false;
   try {

--- a/BrightID/src/utils/operations.js
+++ b/BrightID/src/utils/operations.js
@@ -1,5 +1,4 @@
 import { Alert } from 'react-native';
-import api from '@/api/brightId';
 import store from '@/store';
 import {
   removeOperation,
@@ -9,7 +8,8 @@ import {
 } from '@/actions';
 import fetchUserInfo from '@/actions/fetchUserInfo';
 import i18next from 'i18next';
-import { checkTasks } from '../components/Tasks/TasksSlice';
+import { checkTasks } from '@/components/Tasks/TasksSlice';
+import { selectNodeApi } from '@/reducer/settingsSlice';
 
 const time_fudge = 2 * 60 * 1000; // trace operations for 2 minutes
 
@@ -48,6 +48,8 @@ const handleOpUpdate = (store, op, state, result) => {
 
 export const pollOperations = async () => {
   const operations = selectAllOperations(store.getState());
+  const api = selectNodeApi(store.getState());
+
   let shouldUpdateLocalState = false;
   try {
     for (const op of operations) {

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import { EntityState as _EntityState } from '@reduxjs/toolkit';
 import { RouteProp as _RouteProp } from '@react-navigation/native';
 import {
@@ -40,6 +38,7 @@ declare global {
     operations: OperationsState;
     pendingConnections: PendingConnectionsState;
     recoveryData: RecoveryData;
+    settings: SettingsSlice;
     socialMedia: SocialMediaState;
     tasks: TasksState;
     user: UserState;

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -38,7 +38,7 @@ declare global {
     operations: OperationsState;
     pendingConnections: PendingConnectionsState;
     recoveryData: RecoveryData;
-    settings: SettingsSlice;
+    settings: SettingsState;
     socialMedia: SocialMediaState;
     tasks: TasksState;
     user: UserState;

--- a/BrightID/yarn.lock
+++ b/BrightID/yarn.lock
@@ -2080,6 +2080,17 @@ array.prototype.flatmap@^1.2.3:
     es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
+array.prototype.map@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.3.tgz#1609623618d3d84134a37d4a220030c2bd18420b"
+  integrity sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.5"
+
 asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -3973,6 +3984,28 @@ es-abstract@^1.17.4:
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
+es-abstract@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
+  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.2"
+    is-string "^1.0.5"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.0"
+
 es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
   version "1.18.0-next.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
@@ -3992,6 +4025,37 @@ es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
     object.assign "^4.1.2"
     string.prototype.trimend "^1.0.3"
     string.prototype.trimstart "^1.0.3"
+
+es-aggregate-error@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz#6dfeeb5bf5fd95773ac01f56ec95a57ffeb313f9"
+  integrity sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    function-bind "^1.1.1"
+    functions-have-names "^1.2.1"
+    get-intrinsic "^1.0.1"
+    globalthis "^1.0.1"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-get-iterator@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
+  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.0"
+    has-symbols "^1.0.1"
+    is-arguments "^1.1.0"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.5"
+    isarray "^2.0.5"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -4916,7 +4980,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.1, functions-have-names@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
   integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
@@ -4936,7 +5000,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -5070,6 +5134,13 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globalthis@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.2.tgz#2a235d34f4d8036219f7e34929b5de9e18166b8b"
+  integrity sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@^11.0.1:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
@@ -5112,6 +5183,11 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5126,6 +5202,11 @@ has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
+has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -5487,6 +5568,13 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arguments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -5497,7 +5585,12 @@ is-arrayish@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
-is-boolean-object@^1.0.1:
+is-bigint@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
+  integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
+
+is-boolean-object@^1.0.1, is-boolean-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
   integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
@@ -5509,7 +5602,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
+is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
@@ -5614,6 +5707,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
 is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
@@ -5658,7 +5756,7 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
-is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.1:
+is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.1, is-regex@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
   integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
@@ -5670,6 +5768,11 @@ is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -5691,7 +5794,7 @@ is-subset@^0.1.1:
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
   integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
-is-symbol@^1.0.2:
+is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
@@ -5730,7 +5833,7 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isarray@^2.0.1:
+isarray@^2.0.1, isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
@@ -5810,6 +5913,19 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterate-iterator@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
+  integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
+
+iterate-value@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
+  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
+  dependencies:
+    es-get-iterator "^1.0.2"
+    iterate-iterator "^1.0.1"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"
@@ -8050,6 +8166,19 @@ promise-polyfill@^6.0.1:
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
   integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
 
+promise.any@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/promise.any/-/promise.any-2.0.2.tgz#ed08299df51c2079ecb6688111316879f5c8aa75"
+  integrity sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==
+  dependencies:
+    array.prototype.map "^1.0.2"
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0"
+    es-aggregate-error "^1.0.3"
+    get-intrinsic "^1.1.1"
+    iterate-value "^1.0.2"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -9537,12 +9666,28 @@ string.prototype.trimend@^1.0.1, string.prototype.trimend@^1.0.3:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string.prototype.trimstart@^1.0.1, string.prototype.trimstart@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
   integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   dependencies:
     call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
@@ -10077,6 +10222,16 @@ ultron@~1.1.0:
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
+unbox-primitive@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 unbzip2-stream@^1.3.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
@@ -10321,6 +10476,17 @@ whatwg-url@^8.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Decouple api/brightId.ts from redux store and application state
- Make `userId` and `secretKey` class members that need to be passed in the constructor, instead of looking them up in the store in each method
- When id or secretKey are not provided in the constructor, the "read-only" methods of the API will still work. Other methods will throw an error.
- Move/maintain `seedUrl` in application layer and make it a NodeAPI constructor param
- Move the global NodeAPI instance into application layer (see below)
- Operation tracking: Instead of dispatching `addOperation` at the end of each method, the `op` object is now returned. It is the responsibility of the application layer to `dispatch(addOperation(op))` if the operation status shall be tracked.

With these changes the NodeAPI class is self-contained, so this finally solves the circular dependency between store and NodeAPI :-)

## Introduce `SettingsSlice`
Intended to store application settings. Functionality for now:
- store the current baseUrl
- provide actions to set and clear baseUrl.
The baseUrl is *not* persisted. This makes sure that the app selects the currently fastest responding node at app startup.

## Introduce `NodeApiGate` component
The nodeApi instance is now stored in a React context. The NodeApiGate component has 4 tasks:
- be a ContextProvider for its child components
- prevent interaction with the app unless a valid NodeAPI instance exists. It will display a fallback UI to inform the user if no usable NodeAPI is existing.
- Automatically create (and store in context) a new NodeAPI instance when baseUrl, userId or secretKey changes.
- manage polling for operation results

Components can obtain the API instance from the React Context with the `useContext` hook:
Import: `import { NodeApiContext } from '@/components/NodeApiGate';`
Inside functional component: `const api = useContext(NodeApiContext);`

Since the Api is not a global variable anymore, thunks that require the api need to have it passed with the `dispatch` call.

## Introduce `NodeChooser`
NodeChooser in utils takes an array of baseURL 'candidates'. It returns a promise that will resolve to the baseURL of the fastest working nodeAPI. Checks are made based on the response of the `/brightid/v5/state` endpoint.
Internally it uses `Promise.any`, which results in very fast resolution. The promise resolves as soon as the first valid node reply is obtained, without waiting for further responses to come in.
If no valid response can be obtained within NODE_CHOOSER_TIMEOUT, the promise rejects and an error/retry page is display to the user.

## Other changes
- Display currently used baseUrl on home screen (only in DEV mode). Clicking on the node dispatches `clearBaseUrl` and thus causes the NodeAPIGate to restart the NodeChooser and create a new API Instance.