### PR TITLE
V6 api

### DIFF
--- a/BrightID/android/build.gradle
+++ b/BrightID/android/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 29
         kotlinVersion = '1.3.41'
-        firebaseMessagingVersion = "21.1.0"
     }
     repositories {
         google()

--- a/BrightID/android/build.gradle
+++ b/BrightID/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 29
         kotlinVersion = '1.3.41'
+        firebaseMessagingVersion = "21.1.0"
     }
     repositories {
         google()

--- a/BrightID/e2e/testUtils.js
+++ b/BrightID/e2e/testUtils.js
@@ -47,6 +47,7 @@ const addPhoto = async () => {
     .toBeVisible()
     .withTimeout(15000);
   // create new ID
+  await new Promise(r => setTimeout(r, 10000));
   await expect(element(by.id('submitPhoto'))).toExist();
   await element(by.id('submitPhoto')).tap();
 };

--- a/BrightID/e2e/testUtils.js
+++ b/BrightID/e2e/testUtils.js
@@ -47,7 +47,6 @@ const addPhoto = async () => {
     .toBeVisible()
     .withTimeout(15000);
   // create new ID
-  await new Promise(r => setTimeout(r, 10000));
   await expect(element(by.id('submitPhoto'))).toExist();
   await element(by.id('submitPhoto')).tap();
 };

--- a/BrightID/ios/BrightID.xcodeproj/project.pbxproj
+++ b/BrightID/ios/BrightID.xcodeproj/project.pbxproj
@@ -11,13 +11,14 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		29FCBC232B892E35CF74F3E6 /* libPods-BrightID-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DEDD9A5F22266679ECFB5543 /* libPods-BrightID-tvOS.a */; };
+		18DF61CE5B8A9289C9D7C6A1 /* libPods-BrightID-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8786BDDA2C57E8F512D062F0 /* libPods-BrightID-tvOSTests.a */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* BrightIDTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* BrightIDTests.m */; };
-		302D4190DD8DCB82D3FC8835 /* libPods-BrightID.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B18919273F222B7B31D031DF /* libPods-BrightID.a */; };
-		5E41FCA2DDDD2A7BB383CD1E /* libPods-BrightID-BrightIDTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB703F8EF4280BB75EC8EC8D /* libPods-BrightID-BrightIDTests.a */; };
+		529CB160CD2D51471D9EC316 /* libPods-BrightID-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B57C3FF73F4B6C516395158 /* libPods-BrightID-tvOS.a */; };
+		88303D0123A8957DE0CAB794 /* libPods-BrightID.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CCCDA86F0C5953D1A7A67608 /* libPods-BrightID.a */; };
+		BDDC4DA1A3D2055C5AD03346 /* libPods-BrightID-BrightIDTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E88BCF113EE6784FD7BE668 /* libPods-BrightID-BrightIDTests.a */; };
 		D736B38525394EAB0097A6A6 /* AppCenter-Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = D736B38425394EAB0097A6A6 /* AppCenter-Config.plist */; };
 		D752DD8B251C97E3002622A9 /* ApexNew-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = D752DD82251C97E1002622A9 /* ApexNew-Light.otf */; };
 		D752DD8C251C97E3002622A9 /* Poppins-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = D752DD83251C97E1002622A9 /* Poppins-Regular.otf */; };
@@ -29,7 +30,6 @@
 		D752DD92251C97E3002622A9 /* Poppins-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = D752DD89251C97E3002622A9 /* Poppins-Light.otf */; };
 		D752DD93251C97E3002622A9 /* EurostileRegular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D752DD8A251C97E3002622A9 /* EurostileRegular.ttf */; };
 		D752DD98251CACBB002622A9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D752DD97251CACBB002622A9 /* LaunchScreen.storyboard */; };
-		E419BD5066992594676C639D /* libPods-BrightID-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 24EF8F03B96B3C1A109D7D53 /* libPods-BrightID-tvOSTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,27 +53,29 @@
 		00E356EE1AD99517003FC87E /* BrightIDTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BrightIDTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* BrightIDTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BrightIDTests.m; sourceTree = "<group>"; };
-		109667286A53CAA92325B451 /* Pods-BrightID.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.staging.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.staging.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* BrightID.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BrightID.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = BrightID/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = BrightID/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = BrightID/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = BrightID/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = BrightID/main.m; sourceTree = "<group>"; };
-		15FBEE33F1C263755AF4837B /* Pods-BrightID-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.release.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		214D8768988B4C16363B5E42 /* Pods-BrightID-tvOS.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.staging.xcconfig"; sourceTree = "<group>"; };
-		24EF8F03B96B3C1A109D7D53 /* libPods-BrightID-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2AE5A8A3AFAA9B34675C7C5C /* Pods-BrightID-BrightIDTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.staging.xcconfig"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* BrightID-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BrightID-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* BrightID-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BrightID-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2E2C12DA8AB7402ADE5CA376 /* Pods-BrightID-BrightIDTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.release.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.release.xcconfig"; sourceTree = "<group>"; };
-		3AB5AD765BE6EB626BBF08C5 /* Pods-BrightID-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
-		50A344E10346D1CD29073C7F /* Pods-BrightID-BrightIDTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.debug.xcconfig"; sourceTree = "<group>"; };
-		76DB7ED3FD1C12BE01322FE5 /* Pods-BrightID-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A1B136ADB88DA2F2D0E96351 /* Pods-BrightID-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		B18919273F222B7B31D031DF /* libPods-BrightID.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C112C8D813B07525841BF6C7 /* Pods-BrightID-tvOSTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.staging.xcconfig"; sourceTree = "<group>"; };
-		CB703F8EF4280BB75EC8EC8D /* libPods-BrightID-BrightIDTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-BrightIDTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E88BCF113EE6784FD7BE668 /* libPods-BrightID-BrightIDTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-BrightIDTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B57C3FF73F4B6C516395158 /* libPods-BrightID-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43B04792C6DDDA58E6EE9698 /* Pods-BrightID-BrightIDTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.staging.xcconfig"; sourceTree = "<group>"; };
+		46793CECC7F7569107901499 /* Pods-BrightID-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		58DD59F0EA73FD146FC0CAAB /* Pods-BrightID-tvOSTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.staging.xcconfig"; sourceTree = "<group>"; };
+		6FEC35C2326165C61EA34B19 /* Pods-BrightID-tvOS.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.staging.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.staging.xcconfig"; sourceTree = "<group>"; };
+		70B873D1F8D8DDB32E55D879 /* Pods-BrightID.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.debug.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.debug.xcconfig"; sourceTree = "<group>"; };
+		8786BDDA2C57E8F512D062F0 /* libPods-BrightID-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		90B9CD2A8649602D4F4D973E /* Pods-BrightID.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.release.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.release.xcconfig"; sourceTree = "<group>"; };
+		94A86D65B34A64183D610A6E /* Pods-BrightID-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.release.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		AD10F9301F5BBF66F07F7B61 /* Pods-BrightID-BrightIDTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CB516E02EDE25131F8FFB7D6 /* Pods-BrightID-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOSTests/Pods-BrightID-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		CCCDA86F0C5953D1A7A67608 /* libPods-BrightID.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2587B67A1C2577F5B8730A1 /* Pods-BrightID-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-BrightID-tvOS/Pods-BrightID-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		D73612963C4BD7A5038D82F7 /* Pods-BrightID-BrightIDTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID-BrightIDTests.release.xcconfig"; path = "Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests.release.xcconfig"; sourceTree = "<group>"; };
 		D736B38425394EAB0097A6A6 /* AppCenter-Config.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "AppCenter-Config.plist"; sourceTree = "<group>"; };
 		D752DD81251C9714002622A9 /* BrightID.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = BrightID.entitlements; path = BrightID/BrightID.entitlements; sourceTree = "<group>"; };
 		D752DD82251C97E1002622A9 /* ApexNew-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "ApexNew-Light.otf"; path = "../assets/fonts/ApexNew-Light.otf"; sourceTree = "<group>"; };
@@ -86,11 +88,9 @@
 		D752DD89251C97E3002622A9 /* Poppins-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Poppins-Light.otf"; path = "../assets/fonts/Poppins-Light.otf"; sourceTree = "<group>"; };
 		D752DD8A251C97E3002622A9 /* EurostileRegular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = EurostileRegular.ttf; path = ../assets/fonts/EurostileRegular.ttf; sourceTree = "<group>"; };
 		D752DD97251CACBB002622A9 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		DEDD9A5F22266679ECFB5543 /* libPods-BrightID-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BrightID-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DFD04EF2DD3EE384CCAEB566 /* Pods-BrightID.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.debug.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
-		F3052EA518158E8DC8A03391 /* Pods-BrightID.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.release.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.release.xcconfig"; sourceTree = "<group>"; };
+		F02E2D78681B051517562DE0 /* Pods-BrightID.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrightID.staging.xcconfig"; path = "Target Support Files/Pods-BrightID/Pods-BrightID.staging.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,7 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E41FCA2DDDD2A7BB383CD1E /* libPods-BrightID-BrightIDTests.a in Frameworks */,
+				BDDC4DA1A3D2055C5AD03346 /* libPods-BrightID-BrightIDTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,7 +106,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				302D4190DD8DCB82D3FC8835 /* libPods-BrightID.a in Frameworks */,
+				88303D0123A8957DE0CAB794 /* libPods-BrightID.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,7 +114,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				29FCBC232B892E35CF74F3E6 /* libPods-BrightID-tvOS.a in Frameworks */,
+				529CB160CD2D51471D9EC316 /* libPods-BrightID-tvOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,7 +122,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E419BD5066992594676C639D /* libPods-BrightID-tvOSTests.a in Frameworks */,
+				18DF61CE5B8A9289C9D7C6A1 /* libPods-BrightID-tvOSTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,18 +149,18 @@
 		0A52900DF84229B4AEDF64F1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DFD04EF2DD3EE384CCAEB566 /* Pods-BrightID.debug.xcconfig */,
-				F3052EA518158E8DC8A03391 /* Pods-BrightID.release.xcconfig */,
-				109667286A53CAA92325B451 /* Pods-BrightID.staging.xcconfig */,
-				50A344E10346D1CD29073C7F /* Pods-BrightID-BrightIDTests.debug.xcconfig */,
-				2E2C12DA8AB7402ADE5CA376 /* Pods-BrightID-BrightIDTests.release.xcconfig */,
-				2AE5A8A3AFAA9B34675C7C5C /* Pods-BrightID-BrightIDTests.staging.xcconfig */,
-				A1B136ADB88DA2F2D0E96351 /* Pods-BrightID-tvOS.debug.xcconfig */,
-				15FBEE33F1C263755AF4837B /* Pods-BrightID-tvOS.release.xcconfig */,
-				214D8768988B4C16363B5E42 /* Pods-BrightID-tvOS.staging.xcconfig */,
-				76DB7ED3FD1C12BE01322FE5 /* Pods-BrightID-tvOSTests.debug.xcconfig */,
-				3AB5AD765BE6EB626BBF08C5 /* Pods-BrightID-tvOSTests.release.xcconfig */,
-				C112C8D813B07525841BF6C7 /* Pods-BrightID-tvOSTests.staging.xcconfig */,
+				70B873D1F8D8DDB32E55D879 /* Pods-BrightID.debug.xcconfig */,
+				90B9CD2A8649602D4F4D973E /* Pods-BrightID.release.xcconfig */,
+				F02E2D78681B051517562DE0 /* Pods-BrightID.staging.xcconfig */,
+				AD10F9301F5BBF66F07F7B61 /* Pods-BrightID-BrightIDTests.debug.xcconfig */,
+				D73612963C4BD7A5038D82F7 /* Pods-BrightID-BrightIDTests.release.xcconfig */,
+				43B04792C6DDDA58E6EE9698 /* Pods-BrightID-BrightIDTests.staging.xcconfig */,
+				D2587B67A1C2577F5B8730A1 /* Pods-BrightID-tvOS.debug.xcconfig */,
+				94A86D65B34A64183D610A6E /* Pods-BrightID-tvOS.release.xcconfig */,
+				6FEC35C2326165C61EA34B19 /* Pods-BrightID-tvOS.staging.xcconfig */,
+				46793CECC7F7569107901499 /* Pods-BrightID-tvOSTests.debug.xcconfig */,
+				CB516E02EDE25131F8FFB7D6 /* Pods-BrightID-tvOSTests.release.xcconfig */,
+				58DD59F0EA73FD146FC0CAAB /* Pods-BrightID-tvOSTests.staging.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -184,10 +184,10 @@
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				B18919273F222B7B31D031DF /* libPods-BrightID.a */,
-				CB703F8EF4280BB75EC8EC8D /* libPods-BrightID-BrightIDTests.a */,
-				DEDD9A5F22266679ECFB5543 /* libPods-BrightID-tvOS.a */,
-				24EF8F03B96B3C1A109D7D53 /* libPods-BrightID-tvOSTests.a */,
+				CCCDA86F0C5953D1A7A67608 /* libPods-BrightID.a */,
+				2E88BCF113EE6784FD7BE668 /* libPods-BrightID-BrightIDTests.a */,
+				3B57C3FF73F4B6C516395158 /* libPods-BrightID-tvOS.a */,
+				8786BDDA2C57E8F512D062F0 /* libPods-BrightID-tvOSTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -242,11 +242,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "BrightIDTests" */;
 			buildPhases = (
-				37B43CB739C8DE0AC1D650ED /* [CP] Check Pods Manifest.lock */,
+				49B779EFB2CCB454508E5538 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				E8E2D47524BE3DB1CBD20447 /* [CP] Copy Pods Resources */,
+				99905271999A8A777E7242EE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -262,13 +262,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "BrightID" */;
 			buildPhases = (
-				6FC631E49F2317E38481DE88 /* [CP] Check Pods Manifest.lock */,
+				629593F2DFA07678E1F230B4 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				B32BF58D6591929101F9B9FB /* [CP] Copy Pods Resources */,
+				DAD33E597B63FEF2B4B7C052 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -283,7 +283,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2D02E4BA1E0B4A5E006451C7 /* Build configuration list for PBXNativeTarget "BrightID-tvOS" */;
 			buildPhases = (
-				799AEFD194C185D3B92950D3 /* [CP] Check Pods Manifest.lock */,
+				2EE1ED9252C85EAFEB3E8CCE /* [CP] Check Pods Manifest.lock */,
 				FD10A7F122414F3F0027D42C /* Start Packager */,
 				2D02E4771E0B4A5D006451C7 /* Sources */,
 				2D02E4781E0B4A5D006451C7 /* Frameworks */,
@@ -303,7 +303,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2D02E4BB1E0B4A5E006451C7 /* Build configuration list for PBXNativeTarget "BrightID-tvOSTests" */;
 			buildPhases = (
-				4E654357BE629086E12719AD /* [CP] Check Pods Manifest.lock */,
+				F669560A5E2A38CB41A68E6E /* [CP] Check Pods Manifest.lock */,
 				2D02E48C1E0B4A5D006451C7 /* Sources */,
 				2D02E48D1E0B4A5D006451C7 /* Frameworks */,
 				2D02E48E1E0B4A5D006451C7 /* Resources */,
@@ -439,73 +439,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		37B43CB739C8DE0AC1D650ED /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-BrightID-BrightIDTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4E654357BE629086E12719AD /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-BrightID-tvOSTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6FC631E49F2317E38481DE88 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-BrightID-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		799AEFD194C185D3B92950D3 /* [CP] Check Pods Manifest.lock */ = {
+		2EE1ED9252C85EAFEB3E8CCE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -527,7 +461,105 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B32BF58D6591929101F9B9FB /* [CP] Copy Pods Resources */ = {
+		49B779EFB2CCB454508E5538 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BrightID-BrightIDTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		629593F2DFA07678E1F230B4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BrightID-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		99905271999A8A777E7242EE /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Feather.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Fontisto.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Foundation.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Feather.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Brands.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Regular.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Solid.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Fontisto.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Foundation.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialCommunityIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DAD33E597B63FEF2B4B7C052 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -581,58 +613,26 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BrightID/Pods-BrightID-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E8E2D47524BE3DB1CBD20447 /* [CP] Copy Pods Resources */ = {
+		F669560A5E2A38CB41A68E6E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Feather.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Fontisto.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Foundation.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
-				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
+			inputFileListPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Feather.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Brands.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Regular.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Solid.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Fontisto.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Foundation.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialCommunityIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
+				"$(DERIVED_FILE_DIR)/Pods-BrightID-tvOSTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BrightID-BrightIDTests/Pods-BrightID-BrightIDTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -728,7 +728,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 50A344E10346D1CD29073C7F /* Pods-BrightID-BrightIDTests.debug.xcconfig */;
+			baseConfigurationReference = AD10F9301F5BBF66F07F7B61 /* Pods-BrightID-BrightIDTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -751,7 +751,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2E2C12DA8AB7402ADE5CA376 /* Pods-BrightID-BrightIDTests.release.xcconfig */;
+			baseConfigurationReference = D73612963C4BD7A5038D82F7 /* Pods-BrightID-BrightIDTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -771,7 +771,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFD04EF2DD3EE384CCAEB566 /* Pods-BrightID.debug.xcconfig */;
+			baseConfigurationReference = 70B873D1F8D8DDB32E55D879 /* Pods-BrightID.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -799,7 +799,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F3052EA518158E8DC8A03391 /* Pods-BrightID.release.xcconfig */;
+			baseConfigurationReference = 90B9CD2A8649602D4F4D973E /* Pods-BrightID.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -825,7 +825,7 @@
 		};
 		2D02E4971E0B4A5E006451C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1B136ADB88DA2F2D0E96351 /* Pods-BrightID-tvOS.debug.xcconfig */;
+			baseConfigurationReference = D2587B67A1C2577F5B8730A1 /* Pods-BrightID-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -853,7 +853,7 @@
 		};
 		2D02E4981E0B4A5E006451C7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 15FBEE33F1C263755AF4837B /* Pods-BrightID-tvOS.release.xcconfig */;
+			baseConfigurationReference = 94A86D65B34A64183D610A6E /* Pods-BrightID-tvOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -881,7 +881,7 @@
 		};
 		2D02E4991E0B4A5E006451C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76DB7ED3FD1C12BE01322FE5 /* Pods-BrightID-tvOSTests.debug.xcconfig */;
+			baseConfigurationReference = 46793CECC7F7569107901499 /* Pods-BrightID-tvOSTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -908,7 +908,7 @@
 		};
 		2D02E49A1E0B4A5E006451C7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3AB5AD765BE6EB626BBF08C5 /* Pods-BrightID-tvOSTests.release.xcconfig */;
+			baseConfigurationReference = CB516E02EDE25131F8FFB7D6 /* Pods-BrightID-tvOSTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1113,7 +1113,7 @@
 		};
 		D7E77FF72539749D003EB6A3 /* Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 109667286A53CAA92325B451 /* Pods-BrightID.staging.xcconfig */;
+			baseConfigurationReference = F02E2D78681B051517562DE0 /* Pods-BrightID.staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -1139,7 +1139,7 @@
 		};
 		D7E77FF82539749D003EB6A3 /* Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2AE5A8A3AFAA9B34675C7C5C /* Pods-BrightID-BrightIDTests.staging.xcconfig */;
+			baseConfigurationReference = 43B04792C6DDDA58E6EE9698 /* Pods-BrightID-BrightIDTests.staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -1159,7 +1159,7 @@
 		};
 		D7E77FF92539749D003EB6A3 /* Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 214D8768988B4C16363B5E42 /* Pods-BrightID-tvOS.staging.xcconfig */;
+			baseConfigurationReference = 6FEC35C2326165C61EA34B19 /* Pods-BrightID-tvOS.staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1187,7 +1187,7 @@
 		};
 		D7E77FFA2539749D003EB6A3 /* Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C112C8D813B07525841BF6C7 /* Pods-BrightID-tvOSTests.staging.xcconfig */;
+			baseConfigurationReference = 58DD59F0EA73FD146FC0CAAB /* Pods-BrightID-tvOSTests.staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;

--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -120,7 +120,8 @@
         "lostKeys": "Please create a new BrightID or try recovering your previous BrightID",
         "passwordMatch": "Password and confirm password does not match.",
         "passwordShort": "Your password must be at least 8 characters long.",
-        "trustedSigned": "One of your recovery connections signed your request"
+        "trustedSigned": "One of your recovery connections signed your request",
+        "failedOp": "{{name}} failed!\n{{message}}",
       },
       "title": {
         "lostKeys": "We've lost the BrightID keypair from the device",
@@ -261,17 +262,18 @@
       }
     },
     "button": {
+      "skip": "Skip & do it later",
       "createGroup": "Create Group",
       "next": "Next"
     },
     "label": {
-      "cofounders": "CO-FOUNDERS"
+      "invitees": "INVITEES"
     },
     "placeholder": {
       "groupName": "What is the group name?"
     },
     "text": {
-      "cofounders": "To create a group, you must select two co-founders",
+      "invitees": "Invite group members",
       "noConnections": "No connections"
     }
   },

--- a/BrightID/package.json
+++ b/BrightID/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BrightID",
-  "version": "4.6.3",
+  "version": "4.6.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android --appIdSuffix debug",

--- a/BrightID/src/actions/fakeContact.ts
+++ b/BrightID/src/actions/fakeContact.ts
@@ -39,7 +39,6 @@ export const addFakeConnection = () => async (
       Math.floor(Math.random() * (names.length - 1))
     ];
     const name = `${firstName} ${lastName}`;
-    const score = Math.floor(Math.random() * 99);
 
     // load random photo
     let photo;
@@ -64,7 +63,6 @@ export const addFakeConnection = () => async (
       id: connectId,
       photo,
       name,
-      score,
       profileTimestamp: Date.now(),
       secretKey: uInt8ArrayToB64(secretKey),
       notificationToken: null,
@@ -197,13 +195,11 @@ export const reconnectFakeConnection = (
     // retrieve photo
     photo = await retrieveImage(fakeUser1.photo.filename);
   }
-  const score = Math.floor(Math.random() * 99);
 
   const dataObj = {
     id,
     photo,
     name,
-    score,
     profileTimestamp: Date.now(),
     secretKey: fakeUser1.secretKey,
     notificationToken: null,

--- a/BrightID/src/actions/fetchUserInfo.ts
+++ b/BrightID/src/actions/fetchUserInfo.ts
@@ -1,18 +1,12 @@
 import { InteractionManager } from 'react-native';
 import _ from 'lodash';
-import { updateInvites } from '@/utils/invites';
-import { GROUPS_TYPE } from '@/utils/constants';
 import { NodeApi } from '@/api/brightId';
 import {
-  setGroups,
-  setInvites,
-  setUserScore,
   setVerifications,
+  updateMemberships,
   updateConnections,
   setIsSponsored,
   updateNotifications,
-  setActiveNotification,
-  selectOperationsTotal,
 } from './index';
 
 const fetchUserInfo = (api: NodeApi) => (
@@ -23,67 +17,29 @@ const fetchUserInfo = (api: NodeApi) => (
     InteractionManager.runAfterInteractions(async () => {
       const {
         user: { id },
-        groups: { invites: oldInvites },
       } = getState();
       // const api = selectNodeApi(getState());
-
-      const opTotal = selectOperationsTotal(getState());
-      console.log('opTotal', opTotal);
 
       console.log('refreshing user info', id);
       if (!id) {
         throw new Error('id missing');
       }
       try {
-        const {
-          groups,
-          score,
-          connections = [],
-          isSponsored,
-          invites,
-        } = await api.getUserInfo(id);
-
-        const verifications = await api.getUserVerifications(id);
-
+        const verifications = await api.getVerifications(id);
+        dispatch(setVerifications(verifications));
+        const memberships = await api.getMemberships(id);
+        dispatch(updateMemberships(memberships));
+        const connections = await api.getConnections(id, 'outbound');
         let incomingConns = await api.getConnections(id, 'inbound');
-
         incomingConns = _.keyBy(incomingConns, 'id');
-
         for (const conn of connections) {
           conn.incomingLevel = incomingConns[conn.id]?.level;
         }
+        dispatch(updateConnections(connections));
 
-        if (opTotal === 0) {
-          // don't update data when there are pending operations.
-          dispatch(setGroups(groups));
-          dispatch(updateConnections(connections));
-        }
-        dispatch(setUserScore(score));
-        dispatch(setVerifications(verifications));
-        dispatch(setIsSponsored(isSponsored));
-
-        // this can not be done in reducer because it should be in an async function
-        const newInvites: Invite[] = await updateInvites(invites);
-
-        dispatch(setInvites(newInvites));
-
-        if (newInvites.length > oldInvites.length) {
-          const message =
-            newInvites.length < 1
-              ? `You have ${newInvites.length} new group invitations`
-              : `You've been invited to join ${newInvites[0]?.name}`;
-
-          dispatch(
-            setActiveNotification({
-              title: 'Group Invitation',
-              message,
-              type: GROUPS_TYPE,
-              navigationTarget: 'Notifications',
-              icon: 'AddGroup',
-            }),
-          );
-        }
-        dispatch(updateNotifications());
+        const { sponsored } = await api.getProfile(id);
+        dispatch(setIsSponsored(sponsored));
+        dispatch(updateNotifications(api));
         resolve(null);
       } catch (err) {
         console.log(err.message);

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -9,7 +9,7 @@ import {
 } from '@/utils/encoding';
 import BrightidError from '@/api/brightidError';
 
-const v = 5;
+const v = 6;
 
 export class NodeApi {
   api: ApisauceInstance;
@@ -48,10 +48,10 @@ export class NodeApi {
   }
 
   get apiUrl() {
-    return `${this.baseUrl}/brightid/v5`;
+    return `${this.baseUrl}/brightid/v${v}`;
   }
 
-  static checkHash(response: ApiOkResponse<OperationRes>, message: string) {
+  static checkHash(response: ApiOkResponse<OperationPostRes>, message: string) {
     if (response.data.data?.hash !== hash(message)) {
       throw new Error('Invalid operation hash returned from server');
     }
@@ -103,18 +103,14 @@ export class NodeApi {
     const message = stringify(op);
     console.log(`Connect message: ${message}`);
     op.sig1 = uInt8ArrayToB64(nacl.sign.detached(strToUint8Array(message), sk));
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
   async createGroup(
     groupId: string,
-    id2: string,
-    inviteData2: string,
-    id3: string,
-    inviteData3: string,
     url: string,
     type: string,
   ) {
@@ -124,11 +120,7 @@ export class NodeApi {
 
     const op: AddGroupOp = {
       name,
-      id1: this.id,
-      id2,
-      inviteData2,
-      id3,
-      inviteData3,
+      id: this.id,
       group: groupId,
       url,
       type,
@@ -137,16 +129,16 @@ export class NodeApi {
     };
 
     const message = stringify(op);
-    op.sig1 = uInt8ArrayToB64(
+    op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
-  async dismiss(id2: string, group: string) {
+  async dismiss(dismissee: string, group: string) {
     this.requiresCredentials();
     const name = 'Dismiss';
     const timestamp = Date.now();
@@ -154,7 +146,7 @@ export class NodeApi {
     const op: DismissOp = {
       name,
       dismisser: this.id,
-      dismissee: id2,
+      dismissee,
       group,
       timestamp,
       v,
@@ -164,13 +156,13 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
-  async invite(id2: string, group: string, data: string) {
+  async invite(invitee: string, group: string, data: string) {
     this.requiresCredentials();
     const name = 'Invite';
     const timestamp = Date.now();
@@ -178,7 +170,7 @@ export class NodeApi {
     const op: InviteOp = {
       name,
       inviter: this.id,
-      invitee: id2,
+      invitee,
       group,
       data,
       timestamp,
@@ -189,8 +181,8 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     NodeApi.throwOnError(res);
     return op;
   }
@@ -214,9 +206,9 @@ export class NodeApi {
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
 
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
@@ -237,9 +229,9 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
@@ -270,9 +262,9 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
@@ -293,13 +285,13 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
-  async setSigningKey(params: {
+  async socialRecovery(params: {
     id: string;
     signingKey: string;
     timestamp: number;
@@ -308,8 +300,8 @@ export class NodeApi {
     sig1: string;
     sig2: string;
   }) {
-    const op: SetSigningKeyOp = {
-      name: 'Set Signing Key',
+    const op: SocialRecoveryOp = {
+      name: 'Social Recovery',
       id: params.id,
       signingKey: params.signingKey,
       timestamp: params.timestamp,
@@ -321,9 +313,9 @@ export class NodeApi {
     op.id2 = params.id2;
     op.sig1 = params.sig1;
     op.sig2 = params.sig2;
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const res = await this.api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
@@ -338,26 +330,32 @@ export class NodeApi {
       context,
       contextId,
       timestamp,
-      v,
+      v: 5,
     };
 
     const message = stringify(op);
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationRes, ErrRes>(`/operations`, op);
+    const api = create({
+      baseURL: `${this.baseUrl}/brightid/v5`,
+      headers: { 'Cache-Control': 'no-cache' },
+    });
+    const res = await api.post<OperationPostRes, ErrRes>(`/operations`, op);
     NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationRes>, message);
+    op.hash = NodeApi.checkHash(res as ApiOkResponse<OperationPostRes>, message);
     return op;
   }
 
-  async getUserInfo(id: string) {
-    const res = await this.api.get<UserInfoRes, ErrRes>(`/users/${id}`);
+  async getGroup(id: string) {
+    const res = await this.api.get<GroupRes, ErrRes>(
+      `/groups/${id}`,
+    );
     NodeApi.throwOnError(res);
-    return (res.data as UserInfoRes).data;
+    return (res.data as GroupRes).data;
   }
 
-  async getUserProfile(id: string) {
+  async getProfile(id: string) {
     this.requiresCredentials();
     const requester = this.id;
     const res = await this.api.get<UserProfileRes, ErrRes>(
@@ -367,24 +365,40 @@ export class NodeApi {
     return (res.data as UserProfileRes).data;
   }
 
-  async getUserVerifications(id: string) {
-    const res = await this.api.get<UserVerificationRes, ErrRes>(
+  async getVerifications(id: string) {
+    const res = await this.api.get<UserVerificationsRes, ErrRes>(
       `/users/${id}/verifications`,
     );
     NodeApi.throwOnError(res);
-    return (res.data as UserVerificationRes).data.verifications;
+    return (res.data as UserVerificationsRes).data.verifications;
   }
 
   async getConnections(id: string, direction: 'inbound' | 'outbound') {
-    const res = await this.api.get<UserConnectionRes, ErrRes>(
+    const res = await this.api.get<UserConnectionsRes, ErrRes>(
       `/users/${id}/connections/${direction}`,
     );
     NodeApi.throwOnError(res);
-    return (res.data as UserConnectionRes).data?.connections;
+    return (res.data as UserConnectionsRes).data?.connections;
+  }
+
+  async getMemberships(id: string) {
+    const res = await this.api.get<UserMembershipsRes, ErrRes>(
+      `/users/${id}/memberships`,
+    );
+    NodeApi.throwOnError(res);
+    return (res.data as UserMembershipsRes).data?.memberships;
+  }
+
+  async getInvites(id: string) {
+    const res = await this.api.get<UserInvitesRes, ErrRes>(
+      `/users/${id}/invites`,
+    );
+    NodeApi.throwOnError(res);
+    return (res.data as UserInvitesRes).data?.invites;
   }
 
   async getOperationState(opHash: string) {
-    const res = await this.api.get<OperationStateRes, ErrRes>(
+    const res = await this.api.get<OperationRes, ErrRes>(
       `/operations/${opHash}`,
     );
     if (res.status === 404) {
@@ -396,7 +410,7 @@ export class NodeApi {
       };
     }
     NodeApi.throwOnError(res);
-    return (res.data as OperationStateRes).data;
+    return (res.data as OperationRes).data;
   }
 
   async getApps() {

--- a/BrightID/src/api/operation_types.d.ts
+++ b/BrightID/src/api/operation_types.d.ts
@@ -12,7 +12,7 @@ type NodeOps =
   | LinkContextIdOp
   | RemoveGroupOp
   | RemoveMembershipOp
-  | SetSigningKeyOp;
+  | SocialRecoveryOp;
 
 type AddAdminOp = {
   name: 'Add Admin';
@@ -120,8 +120,8 @@ type RemoveMembershipOp = {
   hash?: string;
 };
 
-type SetSigningKeyOp = {
-  name: 'Set Signing Key';
+type SocialRecoveryOp = {
+  name: 'Social Recovery';
   id: string;
   signingKey: string;
   timestamp: number;

--- a/BrightID/src/api/response_types.d.ts
+++ b/BrightID/src/api/response_types.d.ts
@@ -5,12 +5,14 @@
 type NodeApiRes =
   | AppRes
   | AppsRes
+  | OperationPostRes
   | OperationRes
-  | OperationStateRes
-  | UserConnectionRes
-  | UserInfoRes
+  | UserConnectionsRes
   | UserProfileRes
-  | UserVerificationRes;
+  | UserVerificationsRes
+  | UserInvitesRes
+  | UserMembershipsRes
+  | GroupRes;
 
 type AppRes = {
   data: AppInfo;
@@ -28,43 +30,46 @@ type ErrRes = {
   errorNum: number;
 };
 
-type IpRes = {
-  data: {
-    ip: string;
-  };
-};
-
-type OperationRes = {
+type OperationPostRes = {
   data: {
     hash: string;
   };
 };
 
-type OperationStateRes = {
+type OperationRes = {
+  data: OperationInfo;
+};
+
+type UserConnectionsRes = {
   data: {
-    state: string;
-    result: string;
+    connections: ConnectionInfo[];
   };
 };
 
-type UserConnectionRes = {
+type UserMembershipsRes = {
   data: {
-    connections: Array<{ id: string; level: string; timestamp: number }>;
+    memberships: MembershipInfo[];
   };
 };
 
-type UserVerificationRes = {
+type UserInvitesRes = {
   data: {
-    verifications: Array<Verification>;
+    invites: InviteInfo[];
   };
 };
 
-type UserInfoRes = {
-  data: UserInfo;
+type UserVerificationsRes = {
+  data: {
+    verifications: Verification[];
+  };
 };
 
 type UserProfileRes = {
-  data: UserProfile;
+  data: ProfileInfo;
+};
+
+type GroupRes = {
+  data: GroupInfo;
 };
 
 /**
@@ -84,38 +89,48 @@ type AppInfo = {
   testing: boolean;
 };
 
-type GroupInfo = {
-  id: string;
-  members: string[];
-  type: string;
-  founders: string[];
-  admins: string[];
-  isNew: boolean;
-  url: string;
-  timestamp: number;
-  joined: number;
-  score?: number;
-};
-
-type InviteInfo = {
-  id: string;
-  members: string[];
-  type: string;
-  founders: string[];
-  admins: string[];
-  isNew: boolean;
-  url: string;
-  timestamp: number;
-  inviteId: string;
-  invited: number;
-  inviter: string;
-  data: string;
-  score?: number;
+type OperationInfo = {
+  state: string;
+  result: string;
 };
 
 type ConnectionInfo = {
   id: string;
-  signingKey: string;
+  level: string;
+  timestamp: number;
+  reportReason?: string;
+};
+
+type MembershipInfo = {
+  id: string;
+  timestamp: number;
+};
+
+type GroupInfo = {
+  id: string;
+  members: string[];
+  invites: InviteInfo[];
+  admins: string[];
+  type: string;
+  url: string;
+  timestamp: number;
+  seed?: boolean;
+  region?: string;
+  info?: string;
+};
+
+type InviteInfo = {
+  id: string;
+  group: string;
+  inviter: string;
+  invitee: number;
+  timestamp: number;
+  data: string;
+};
+
+type ConnectionInfo = {
+  id: string;
+  signingKeys: string[];
   level: ConnectionLevel;
   incomingLevel?: ConnectionLevel;
   verifications: string[];
@@ -125,25 +140,10 @@ type ConnectionInfo = {
     [id: string]: string;
   };
   createdAt: number;
-  score?: number;
   status?: string;
 };
 
-type UserInfo = {
-  createdAt: number;
-  groups: GroupInfo[];
-  invites: InviteInfo[];
-  connections: ConnectionInfo[];
-  verifications: string[];
-  isSponsored: boolean;
-  trusted: string[];
-  flaggers: {
-    [id: string]: string;
-  };
-  score?: number;
-};
-
-type UserProfile = {
+type ProfileInfo = {
   connectionsNum: number;
   groupsNum: number;
   mutualConnections: string[];
@@ -152,4 +152,5 @@ type UserProfile = {
   createdAt: number;
   reports: Array<{ id: string; reportReason: string }>;
   verifications: Array<{ name: string }>;
+  signingKeys: string[];
 };

--- a/BrightID/src/components/Connections/ConnectionScreenController.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreenController.tsx
@@ -48,7 +48,7 @@ function ConnectionScreenController() {
       const fetchData = async (connectionId) => {
         setLoading(true);
         console.log(`fetching connection info for ${connectionId}`);
-        const profile = await api.getUserProfile(connectionId);
+        const profile = await api.getProfile(connectionId);
         setVerifications(profile.verifications);
         setConnectedAt(profile.connectedAt);
         setMutualConnections(

--- a/BrightID/src/components/Connections/ConnectionsScreen.tsx
+++ b/BrightID/src/components/Connections/ConnectionsScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import { StyleSheet, View, StatusBar, FlatList } from 'react-native';
-import { useDispatch, useSelector } from '@/store';
+import { useDispatch, useSelector, store } from '@/store';
 import { useTranslation } from 'react-i18next';
-import fetchUserInfo from '@/actions/fetchUserInfo';
 import { useNavigation } from '@react-navigation/native';
 import FloatingActionButton from '@/components/Helpers/FloatingActionButton';
 import EmptyList from '@/components/Helpers/EmptyList';
@@ -12,6 +11,7 @@ import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import ConnectionCard from './ConnectionCard';
+import { updateConnections } from '@/actions';
 
 /**
  * Connection screen of BrightID
@@ -47,8 +47,11 @@ export const ConnectionsScreen = () => {
 
   const ConnectionList = useMemo(() => {
     const onRefresh = async () => {
+      console.log('Reloading Connections');
+      const { user: { id } } = store.getState();
       try {
-        await dispatch(fetchUserInfo(api));
+        const conns = await api.getConnections(id, 'outbound');
+        await dispatch(updateConnections(conns));
       } catch (err) {
         console.log(err.message);
       }

--- a/BrightID/src/components/EditProfile/ChangePasswordModal.tsx
+++ b/BrightID/src/components/EditProfile/ChangePasswordModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {
   Alert,
   View,
@@ -11,6 +11,7 @@ import { BlurView } from '@react-native-community/blur';
 import Spinner from 'react-native-spinkit';
 import { setInternetCredentials } from 'react-native-keychain';
 import { useTranslation } from 'react-i18next';
+import { NodeApiContext } from '@/components/NodeApiGate';
 import { BACKUP_URL, ORANGE } from '@/utils/constants';
 import { DEVICE_LARGE, DEVICE_IOS } from '@/utils/deviceConstants';
 import {
@@ -95,7 +96,8 @@ const ChangePasswordModal = ({ navigation }: props) => {
     setBackupInProgress(false);
 
     // update notifications to make sure the `set backup password` notification is removed
-    dispatch(updateNotifications());
+    const api = useContext(NodeApiContext);
+    dispatch(updateNotifications(api));
 
     // finally close modal
     navigation.goBack();

--- a/BrightID/src/components/Groups/GroupCard.js
+++ b/BrightID/src/components/Groups/GroupCard.js
@@ -15,42 +15,25 @@ class GroupCard extends React.PureComponent {
   setStatus = () => {
     const { group, t } = this.props;
     const concatenationString = t('common.language.and', 'and');
-    if (group.isNew) {
-      const notJoinedIds = group.founders.filter(
-        (founder) => !group.members.includes(founder),
-      );
-      const notJoinedNames = ids2connections(notJoinedIds).map((o) => o.name);
-      return (
-        <View style={styles.waitingContainer}>
-          <Text style={styles.waitingMessage}>
-            {t('groups.text.waitingForMembers', {
-              // TODO: This concatenation assumes english grammar and will not work well in all languages
-              list: notJoinedNames.join(` ${concatenationString} `),
-            })}
+    const unknowsCount = ids2connections(group.members).filter(
+      (o) => o.name === 'Stranger',
+    ).length;
+    return (
+      <View>
+        <View style={styles.membersContainer}>
+          <Text style={styles.membersLabel}>
+            {t('groups.label.knownMembers')}
           </Text>
+          <Text style={styles.membersKnown}>
+            {group.members.length - unknowsCount}{' '}
+          </Text>
+          <Text style={styles.membersLabel}>
+            {t('groups.label.unknownMembers')}
+          </Text>
+          <Text style={styles.membersUnknown}>{unknowsCount}</Text>
         </View>
-      );
-    } else {
-      const unknowsCount = ids2connections(group.members).filter(
-        (o) => o.name === 'Stranger',
-      ).length;
-      return (
-        <View>
-          <View style={styles.membersContainer}>
-            <Text style={styles.membersLabel}>
-              {t('groups.label.knownMembers')}
-            </Text>
-            <Text style={styles.membersKnown}>
-              {group.members.length - unknowsCount}{' '}
-            </Text>
-            <Text style={styles.membersLabel}>
-              {t('groups.label.unknownMembers')}
-            </Text>
-            <Text style={styles.membersUnknown}>{unknowsCount}</Text>
-          </View>
-        </View>
-      );
-    }
+      </View>
+    );
   };
 
   render() {

--- a/BrightID/src/components/Groups/GroupPhoto.js
+++ b/BrightID/src/components/Groups/GroupPhoto.js
@@ -6,16 +6,6 @@ import { groupCirclePhotos } from '@/utils/groups';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { LIGHT_GREY } from '@/theme/colors';
 
-const photoStyle = (photo) => {
-  const style = { ...styles.photo };
-  if (photo.faded) {
-    style.opacity = 0.25;
-  }
-  return {
-    ...style,
-  };
-};
-
 const GroupPhoto = ({ group }) => {
   if (group.photo?.filename) {
     return (
@@ -39,14 +29,13 @@ const GroupPhoto = ({ group }) => {
       }
       return item;
     });
-
     return (
       <View style={styles.container}>
         <View style={styles.topPhotos}>
           {circlePhotos[0] && (
             <Image
               source={circlePhotos[0].source}
-              style={photoStyle(circlePhotos[0])}
+              style={styles.photo}
             />
           )}
         </View>
@@ -54,13 +43,13 @@ const GroupPhoto = ({ group }) => {
           {circlePhotos[1] && (
             <Image
               source={circlePhotos[1].source}
-              style={photoStyle(circlePhotos[1])}
+              style={styles.photo}
             />
           )}
           {circlePhotos[2] && (
             <Image
               source={circlePhotos[2].source}
-              style={photoStyle(circlePhotos[2])}
+              style={styles.photo}
             />
           )}
         </View>
@@ -86,9 +75,6 @@ const styles = StyleSheet.create({
     width: DEVICE_LARGE ? 40 : 32,
     height: DEVICE_LARGE ? 40 : 32,
     backgroundColor: LIGHT_GREY,
-  },
-  faded: {
-    opacity: 0.25,
   },
   topPhotos: {
     alignItems: 'center',

--- a/BrightID/src/components/Groups/Members/InviteListScreen.js
+++ b/BrightID/src/components/Groups/Members/InviteListScreen.js
@@ -47,7 +47,8 @@ export class InviteListScreen extends Component {
     const group = route.params?.group;
 
     try {
-      const data = await encryptAesKey(group?.aesKey, connection.signingKey);
+      const { signingKeys } = await api.getProfile(connection.id);
+      const data = await encryptAesKey(group?.aesKey, signingKeys[0]);
       const op = await api.invite(connection.id, group?.id, data);
       dispatch(addOperation(op));
       Alert.alert(

--- a/BrightID/src/components/Groups/Members/MembersScreen.js
+++ b/BrightID/src/components/Groups/Members/MembersScreen.js
@@ -18,6 +18,7 @@ import { innerJoin } from 'ramda';
 import { useTranslation } from 'react-i18next';
 import {
   leaveGroup,
+  updateGroup,
   dismissFromGroup,
   addAdmin,
   selectAllConnections,
@@ -42,7 +43,6 @@ function MembersScreen(props) {
   const { group, admins, members } = useSelector((state) =>
     groupByIdSelector(state, groupID),
   );
-
   const [contextActions, setContextActions] = useState([]);
   const { t } = useTranslation();
   const { showActionSheetWithOptions } = useActionSheet();
@@ -175,6 +175,13 @@ function MembersScreen(props) {
     setContextActions(actions);
   }, [user.id, admins, members, ACTION_INVITE, ACTION_LEAVE, ACTION_CANCEL]);
 
+  useEffect(() => {
+    console.log(`updating group info ${groupID}`);
+    api.getGroup(groupID).then((data) => {
+      dispatch(updateGroup(data));
+    });
+  }, []);
+
   // Only include the group members that user knows (is connected with), and the user itself
   const groupMembers = useMemo(() => {
     // TODO: userObj is ugly and just here to satisfy flow typecheck for 'connection' type.
@@ -183,11 +190,10 @@ function MembersScreen(props) {
       id: user.id,
       name: user.name,
       photo: user.photo,
-      score: user.score,
       aesKey: '',
       connectionDate: 0,
       status: '',
-      signingKey: '',
+      signingKeys: [],
       createdAt: 0,
       hasPrimaryGroup: false,
     };

--- a/BrightID/src/components/Groups/NewGroups/NewGroupCard.js
+++ b/BrightID/src/components/Groups/NewGroups/NewGroupCard.js
@@ -9,7 +9,7 @@ import { withTranslation } from 'react-i18next';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { GREY, WHITE, GREEN, BLACK } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
-import { toggleNewGroupCoFounder } from '../actions';
+import { toggleNewGroupInvitee } from '../actions';
 
 /**
  * Connection Card in the Connections Screen
@@ -29,8 +29,8 @@ class NewGroupCard extends React.PureComponent {
 
   handleGroupSelect = () => {
     console.log('pressed');
-    let { toggleCoFounder, id } = this.props;
-    toggleCoFounder(id);
+    let { toggleInvitee, id } = this.props;
+    toggleInvitee(id);
   };
 
   renderActionButton = () => {
@@ -38,7 +38,7 @@ class NewGroupCard extends React.PureComponent {
     if (groups) {
       return (
         <TouchableOpacity
-          testID="checkCoFounderBtn"
+          testID="checkInviteeBtn"
           style={styles.moreIcon}
           onPress={this.handleGroupSelect}
         >
@@ -140,5 +140,5 @@ const styles = StyleSheet.create({
 });
 
 export default connect(null, (dispatch) => ({
-  toggleCoFounder: (id) => dispatch(toggleNewGroupCoFounder(id)),
+  toggleInvitee: (id) => dispatch(toggleNewGroupInvitee(id)),
 }))(withTranslation()(NewGroupCard));

--- a/BrightID/src/components/Groups/NewGroups/NewGroupScreen.js
+++ b/BrightID/src/components/Groups/NewGroups/NewGroupScreen.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import store from '@/store';
 import emitter from '@/emitter';
-import { clearNewGroupCoFounders } from '@/actions';
+import { clearNewGroupInvitees } from '@/actions';
 import { BLUE, LIGHT_GREY, ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE, DEVICE_TYPE } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
@@ -68,7 +68,7 @@ export class NewGroupScreen extends React.Component {
       emitter.on('creatingGroupChannel', this.updateCreationState);
     });
     navigation.addListener('blur', () => {
-      dispatch(clearNewGroupCoFounders());
+      dispatch(clearNewGroupInvitees());
       emitter.off('creatingGroupChannel', this.updateCreationState);
     });
   }
@@ -78,8 +78,8 @@ export class NewGroupScreen extends React.Component {
   };
 
   cardIsSelected = (card) => {
-    const { newGroupCoFounders } = this.props;
-    return newGroupCoFounders.includes(card.id);
+    const { newGroupInvitees } = this.props;
+    return newGroupInvitees.includes(card.id);
   };
 
   createGroup = async () => {
@@ -102,21 +102,24 @@ export class NewGroupScreen extends React.Component {
 
   renderButtonOrSpinner = () => {
     const { t } = this.props;
-    const buttonDisabled = this.props.newGroupCoFounders.length < 2;
+    const skip = this.props.newGroupInvitees.length < 1;
     return !this.state.creating ? (
       <View style={styles.createGroupButtonContainer}>
         <TouchableOpacity
           testID="createNewGroupBtn"
           onPress={this.createGroup}
           style={
-            buttonDisabled
-              ? { ...styles.createGroupButton, opacity: 0.4 }
+            skip
+              ? { ...styles.createGroupButton, ...styles.skipButton }
               : styles.createGroupButton
           }
-          disabled={buttonDisabled}
         >
           <Text style={styles.buttonInnerText}>
-            {t('createGroup.button.createGroup')}
+            {
+              skip
+              ? t('createGroup.button.skip')
+              : t('createGroup.button.createGroup')
+            }
           </Text>
         </TouchableOpacity>
       </View>
@@ -149,10 +152,10 @@ export class NewGroupScreen extends React.Component {
           <View testID="newGroupScreen" style={styles.mainContainer}>
             <View style={styles.titleContainer}>
               <Text style={styles.titleText}>
-                {t('createGroup.label.cofounders')}
+                {t('createGroup.label.invitees')}
               </Text>
               <Text style={styles.infoText}>
-                {t('createGroup.text.cofounders')}
+                {t('createGroup.text.invitees')}
               </Text>
             </View>
             <View style={styles.mainContainer}>
@@ -272,7 +275,9 @@ const styles = StyleSheet.create({
     paddingBottom: 12,
     marginBottom: DEVICE_TYPE === 'large' ? 30 : 25,
   },
-
+  skipButton: {
+    backgroundColor: BLUE,
+  },
   buttonInnerText: {
     fontFamily: 'ApexNew-Medium',
     color: WHITE,
@@ -292,6 +297,6 @@ const styles = StyleSheet.create({
 });
 
 export default connect((state) => ({
-  newGroupCoFounders: state.groups.newGroupCoFounders,
+  newGroupInvitees: state.groups.newGroupInvitees,
   connections: verifiedConnectionsSelector(state),
 }))(withTranslation()(NewGroupScreen));

--- a/BrightID/src/components/Groups/models/sortingUtility.js
+++ b/BrightID/src/components/Groups/models/sortingUtility.js
@@ -1,3 +1,3 @@
-export const compareJoinedDesc = (groupA, groupB) => {
-  return groupB.joined - groupA.joined;
+export const compareCreatedDesc = (groupA, groupB) => {
+  return groupB.timestamp - groupA.timestamp;
 };

--- a/BrightID/src/components/Helpers/CirclePhoto.tsx
+++ b/BrightID/src/components/Helpers/CirclePhoto.tsx
@@ -3,11 +3,6 @@ import { Image, StyleSheet, View } from 'react-native';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { LIGHT_GREY } from '@/theme/colors';
 
-const photoStyle = (photo) => ({
-  ...styles.photo,
-  opacity: photo.faded ? 0.25 : 1,
-});
-
 const CirclePhoto = ({ circlePhotos }) => {
   console.log(circlePhotos);
   return (
@@ -46,9 +41,6 @@ const styles = StyleSheet.create({
     width: DEVICE_LARGE ? 40 : 32,
     height: DEVICE_LARGE ? 40 : 32,
     backgroundColor: LIGHT_GREY,
-  },
-  faded: {
-    opacity: 0.25,
   },
   topPhotos: {
     alignItems: 'center',

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -63,7 +63,10 @@ export const HomeScreen = (props) => {
   const photoFilename = useSelector(
     (state: State) => state.user.photo.filename,
   );
-  const groupsCount = useSelector((state: State) => state.groups.groups.length);
+  const groupsCount = useSelector(
+    (state: State) => state.groups.groups
+      .filter(g => g.state === 'initiated' || g.state === 'verified').length
+  );
   const connectionsCount = useSelector(verifiedConnectionsSelector).length;
   const linkedContextsCount = useSelector(linkedContextTotal);
   const verifiedApps = useSelector(verifiedAppsSelector);

--- a/BrightID/src/components/Notifications/InviteCard.tsx
+++ b/BrightID/src/components/Notifications/InviteCard.tsx
@@ -58,10 +58,6 @@ const InviteCard = (props) => {
           onPress: async () => {
             try {
               await dispatch(rejectInvite(invite.id));
-              if (invite.isNew) {
-                const op = await api.deleteGroup(invite.id);
-                dispatch(addOperation(op));
-              }
             } catch (err) {
               Alert.alert(
                 t('notifications.alert.title.failureRejectGroupInvite'),
@@ -77,24 +73,24 @@ const InviteCard = (props) => {
 
   const handleAcceptInvite = async () => {
     try {
-      const op = await api.joinGroup(invite.id);
+      const op = await api.joinGroup(invite.group.id);
       dispatch(addOperation(op));
       dispatch(acceptInvite(invite.id));
-      await dispatch(joinGroup(invite));
+      await dispatch(joinGroup(invite.group));
       Alert.alert(
         t('common.alert.success'),
         t('notifications.alert.text.successGroupInvite', {
           defaultValue: 'You joined {{groupName}}',
-          groupName: getGroupName(invite),
+          groupName: getGroupName(invite.group),
         }),
       );
       if (backupCompleted) {
         await dispatch(backupUser());
-        if (invite.photo && invite.photo.filename) {
-          await dispatch(backupPhoto(invite.id, invite.photo.filename));
+        if (invite.group.photo && invite.group.photo.filename) {
+          await dispatch(backupPhoto(invite.group.id, invite.group.photo.filename));
         }
       }
-      navigation.navigate('Members', { group: invite });
+      navigation.navigate('Members', { group: invite.group });
     } catch (err) {
       if (err instanceof BrightidError) {
         // Something went wrong in the backend while applying operation
@@ -111,10 +107,10 @@ const InviteCard = (props) => {
   return (
     <View style={styles.container}>
       <View style={styles.photoContainer}>
-        <GroupPhoto group={invite} />
+        <GroupPhoto group={invite.group} />
       </View>
       <View style={styles.info}>
-        <Text style={styles.name}>{getGroupName(invite)}</Text>
+        <Text style={styles.name}>{getGroupName(invite.group)}</Text>
         <Text style={styles.invitationMsg}>
           {t('notifications.item.text.pendingGroupInvite', {
             name: inviter?.name,

--- a/BrightID/src/components/Notifications/NotificationsScreen.tsx
+++ b/BrightID/src/components/Notifications/NotificationsScreen.tsx
@@ -27,9 +27,9 @@ import { fontSize } from '@/theme/fonts';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { createSelector } from '@reduxjs/toolkit';
 import { selectAllUnconfirmedConnections } from '@/components/PendingConnections/pendingConnectionSlice';
-import fetchUserInfo from '@/actions/fetchUserInfo';
 import EmptyList from '@/components/Helpers/EmptyList';
 import { photoDirectory } from '@/utils/filesystem';
+import { updateNotifications } from '@/actions/index';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import NotificationCard from './NotificationCard';
 import InviteCard from './InviteCard';
@@ -52,15 +52,14 @@ const useRefresh: () => [boolean, () => void] = () => {
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = () => {
     setRefreshing(true);
-    dispatch(fetchUserInfo(api))
+    dispatch(updateNotifications(api))
       .then(() => {
-        setRefreshing(true);
+        setRefreshing(false);
       })
       .catch((err) => {
         console.log(err.message);
         setRefreshing(false);
       });
-    setRefreshing(false);
   };
   return [refreshing, onRefresh];
 };
@@ -117,7 +116,7 @@ const InviteList = () => {
     <FlatList
       contentContainerStyle={{ paddingBottom: 50, flexGrow: 1 }}
       data={invites}
-      keyExtractor={({ inviteId }, index) => inviteId + index}
+      keyExtractor={({ id }, index) => id + index}
       showsHorizontalScrollIndicator={false}
       showsVerticalScrollIndicator={false}
       onRefresh={onRefresh}
@@ -284,11 +283,11 @@ export const NotificationsScreen = () => {
 
   useFocusEffect(
     useCallback(() => {
-      dispatch(fetchUserInfo(api));
+      dispatch(updateNotifications(api));
     }, [api, dispatch]),
   );
 
-  console.log('renderingNotificationScreen');
+  console.log('Rendering Notification Screen');
 
   return (
     <>

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionCard.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveringConnectionCard.tsx
@@ -210,11 +210,6 @@ const styles = StyleSheet.create({
     fontFamily: 'Poppins-Medium',
     fontSize: fontSize[16],
   },
-  scoreContainer: {
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-  },
   connectedText: {
     fontFamily: 'ApexNew-Book',
     fontSize: fontSize[12],

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/backupThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/backupThunks.ts
@@ -65,7 +65,7 @@ export const backupUser = () => async (
 ) => {
   try {
     const {
-      user: { id, score, name, photo },
+      user: { id, name, photo },
       groups: { groups },
     } = getState();
     const connections = selectAllConnections(getState());
@@ -73,7 +73,6 @@ export const backupUser = () => async (
     const userData = {
       id,
       name,
-      score,
       photo,
     };
 

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/channelUploadThunks.js
@@ -19,11 +19,11 @@ export const uploadSig = ({ id, aesKey, channelApi }) => async (
   const { signingKey, timestamp } = await loadRecoveryData(channelApi, aesKey);
 
   const op = {
-    name: 'Set Signing Key',
+    name: 'Social Recovery',
     id,
     signingKey,
     timestamp,
-    v: 5,
+    v: 6,
   };
   const message = stringify(op);
   const sig = uInt8ArrayToB64(
@@ -153,7 +153,7 @@ export const uploadMutualInfo = ({
       mutualConnections.push(user);
     }
 
-    const otherSideGroups = await nodeApi.getUserInfo(conn.id)?.groups;
+    const otherSideGroups = await nodeApi.getUserMemberships(conn.id);
     const mutualGroups = otherSideGroups
       ? otherSideGroups.filter((g) => groups[g.id]).map((g) => groups[g.id])
       : [];

--- a/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
+++ b/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
@@ -76,7 +76,6 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
   };
 
   console.log(`rendering ${pendingConnection.name}`);
-
   return (
     <View style={styles.previewContainer}>
       {isReconnect ? (

--- a/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
+++ b/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
@@ -29,7 +29,6 @@ const pendingConnectionsAdapter = createEntityAdapter<PendingConnection>();
    - 'brightId': the brightId if the connection
    - 'name'
    - 'photo' (base64-encoded)
-   - 'score'
  */
 export enum pendingConnection_states {
   INITIAL = 'INITIAL',
@@ -109,7 +108,7 @@ export const newPendingConnection = createAsyncThunk<
       existingConnection?: Connection;
     } = {};
     try {
-      connectionInfo = await api.getUserProfile(decryptedObj.id);
+      connectionInfo = await api.getProfile(decryptedObj.id);
     } catch (err) {
       if (err instanceof BrightidError && err.errorNum === USER_NOT_FOUND) {
         // this must be a new user not yet existing on backend. Return empty object.
@@ -198,7 +197,6 @@ const pendingConnectionsSlice = createSlice({
           id: brightId,
           name,
           photo,
-          score,
           profileTimestamp,
           initiator,
           connectionsNum,
@@ -221,7 +219,6 @@ const pendingConnectionsSlice = createSlice({
           brightId,
           name,
           photo,
-          score,
           profileTimestamp,
           initiator,
           connectionsNum,

--- a/BrightID/src/reducer/connectionsSlice.ts
+++ b/BrightID/src/reducer/connectionsSlice.ts
@@ -44,6 +44,7 @@ const connectionsSlice = createSlice({
       state.connectionsSort = action.payload;
     },
     updateConnections(state, action: PayloadAction<ConnectionInfo[]>) {
+      console.log('updating connections state');
       const { entities, ids } = original(state.connections);
 
       // check to see if any connections are deleted

--- a/BrightID/src/reducer/groupsSlice.ts
+++ b/BrightID/src/reducer/groupsSlice.ts
@@ -1,3 +1,4 @@
+import { difference } from 'ramda';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RESET_STORE } from '@/actions/resetStore';
 import { INVITE_ACCEPTED, INVITE_REJECTED } from '@/utils/constants';
@@ -5,7 +6,7 @@ import { INVITE_ACCEPTED, INVITE_REJECTED } from '@/utils/constants';
 /* ******** INITIAL STATE ************** */
 
 const initialState: GroupsState = {
-  newGroupCoFounders: [],
+  newGroupInvitees: [],
   groups: [],
   invites: [],
   searchParam: '',
@@ -19,43 +20,43 @@ const groupsSlice = createSlice({
     createGroup(state, action: PayloadAction<Group>) {
       state.groups.push(action.payload);
     },
+    updateGroup(state, action: PayloadAction<Group>) {
+      const group = state.groups.find((group) => group.id === action.payload.id);
+      Object.assign(group, action.payload);
+    },
     deleteGroup(state, action: PayloadAction<Group>) {
       state.groups = state.groups.filter(
         (group) => group.id !== action.payload.id,
       );
     },
-    setNewGroupCoFounders(state, action: PayloadAction<string[]>) {
-      state.newGroupCoFounders = action.payload;
+    setNewGroupInvitees(state, action: PayloadAction<string[]>) {
+      state.newGroupInvitees = action.payload;
     },
-    clearNewGroupCoFounders(state) {
-      state.newGroupCoFounders = [];
+    clearNewGroupInvitees(state) {
+      state.newGroupInvitees = [];
     },
     setGroups(state, action: PayloadAction<Group[]>) {
-      const mergeWithOld = (group: Group) => {
-        const oldGroup = state.groups.find((g) => g.id === group.id);
-        if (oldGroup) {
-          group.name = oldGroup.name;
-          group.photo = oldGroup.photo;
-          group.aesKey = oldGroup.aesKey;
+      state.groups = action.payload;
+    },
+    updateMemberships(state, action: PayloadAction<MembershipInfo[]>) {
+      state.groups.forEach((group) => {
+        const membership = action.payload.find((membership) => membership.id === group.id);
+        if (!membership) {
+          group.state = 'dismissed';
         }
-        return group;
-      };
-
-      state.groups = action.payload.map(mergeWithOld);
+      });
+      action.payload.forEach((membership) => {
+        const group = state.groups.find((group) => group.id === membership.id);
+        group.state = 'verified';
+        group.joined = membership.timestamp;
+      });
     },
     joinGroup(state, action: PayloadAction<Group>) {
-      const group = action.payload;
-      if (group.members.length > 1) {
-        // joining a group that already has 2 members, so I'm either the last founder
-        // or an additional member -> the group is complete
-        group.isNew = false;
-      }
-      state.groups.push(group);
+      state.groups.push(action.payload);
     },
     leaveGroup(state, action: PayloadAction<Group>) {
-      state.groups = state.groups.filter(
-        (group) => group.id !== action.payload.id,
-      );
+      const group = state.groups.find((group) => group.id === action.payload.id);
+      group.state = 'dismissed';
     },
     dismissFromGroup(
       state,
@@ -115,10 +116,12 @@ const groupsSlice = createSlice({
 // Export channel actions
 export const {
   createGroup,
+  updateGroup,
   deleteGroup,
-  setNewGroupCoFounders,
-  clearNewGroupCoFounders,
+  setNewGroupInvitees,
+  clearNewGroupInvitees,
   setGroups,
+  updateMemberships,
   joinGroup,
   leaveGroup,
   dismissFromGroup,

--- a/BrightID/src/reducer/types.d.ts
+++ b/BrightID/src/reducer/types.d.ts
@@ -42,25 +42,30 @@ type Connection = Partial<ConnectionInfo> & Partial<LocalConnectionData>;
  */
 
 type GroupsState = {
-  newGroupCoFounders: string[];
+  newGroupInvitees: string[];
   invites: Invite[];
   groups: Group[];
   searchParam: string;
   searchOpen: boolean;
 };
 
-type Group = Partial<GroupInfo> & {
+type Group = GroupInfo & {
   name?: string;
   photo?: { filename: string };
   aesKey?: string;
+  joined: number;
+  state: string;
 };
 
 type Invite = InviteInfo & {
-  name?: string;
-  state?: string;
-  photo?: { filename: string };
-  aesKey?: string;
+  group: Group;
+  state: string;
 };
+
+// type Invite = Omit<InviteInfo, 'group'> & {
+//   group: Group;
+//   state: string;
+// };
 
 /**
  * KeypairSlice

--- a/BrightID/src/reducer/userSlice.ts
+++ b/BrightID/src/reducer/userSlice.ts
@@ -2,7 +2,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RESET_STORE } from '@/actions/resetStore';
 
 const initialState: UserState = {
-  score: 0,
   isSponsored: false,
   name: '',
   photo: { filename: '' },
@@ -19,9 +18,6 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
-    setUserScore(state, action) {
-      state.score = action.payload;
-    },
     setIsSponsored(state, action) {
       state.isSponsored = action.payload;
     },
@@ -58,7 +54,6 @@ const userSlice = createSlice({
     },
     hydrateUser(state, action) {
       const {
-        score,
         name,
         photo,
         backupCompleted,
@@ -67,7 +62,6 @@ const userSlice = createSlice({
       } = action.payload;
 
       state.backupCompleted = backupCompleted;
-      state.score = score;
       state.name = name;
       state.photo = photo;
       state.id = id;
@@ -83,7 +77,6 @@ const userSlice = createSlice({
 
 // Export channel actions
 export const {
-  setUserScore,
   setIsSponsored,
   setPhoto,
   setSearchParam,

--- a/BrightID/src/store/index.ts
+++ b/BrightID/src/store/index.ts
@@ -41,7 +41,7 @@ const connectionsPersistConfig = {
 const groupsPersistConfig = {
   ...fsPersistConfig,
   key: 'groups',
-  blacklist: ['searchParam', 'searchOpen', 'newGroupCoFounders'],
+  blacklist: ['searchParam', 'searchOpen', 'newGroupInvitees'],
 };
 
 const notificationsPersistConfig = {

--- a/BrightID/src/store/migrations/root.js
+++ b/BrightID/src/store/migrations/root.js
@@ -95,7 +95,6 @@ const rootMigrations = {
       name: '',
       timestamp: 0,
       signedMessage: '',
-      score: 0,
     };
     return state;
   },

--- a/BrightID/src/utils/groups.js
+++ b/BrightID/src/utils/groups.js
@@ -10,7 +10,7 @@ const threeKnownMembers = (group) => {
     user: { id, photo, name },
   } = store.getState();
   const connections = selectAllConnections(store.getState());
-  const { founders, members, isNew } = group;
+  const { members } = group;
   const connsWithMe = [
     ...connections,
     {
@@ -19,27 +19,18 @@ const threeKnownMembers = (group) => {
       id,
     },
   ];
-  let list = (isNew ? founders : members)
+  let list = members
     .map((u) => connsWithMe.find((conn) => conn.id === u))
     .filter((u) => u)
-    .sort((u1, u2) => (founders.includes(u1) ? -1 : 1))
+    .sort((u1, u2) => (group.admins.includes(u1) ? -1 : 1))
     .slice(0, 3);
-
   return list;
 };
 
 export const groupCirclePhotos = (group) => {
-  const { members } = group;
-
-  const photos = threeKnownMembers(group).map((member) => {
-    // If a founder isn't in members, that founder hasn't joined yet and
-    // their photo will be faded.
-
-    const faded = group?.isNew && !members.includes(member.id);
-
-    return { photo: member.photo, faded };
+  return threeKnownMembers(group).map((member) => {
+    return { photo: member.photo };
   });
-  return photos;
 };
 
 export const getGroupName = (group) => {
@@ -53,18 +44,18 @@ export const getGroupName = (group) => {
 
 export const ids2connections = (ids) => {
   const {
-    user: { name, id, photo, score },
+    user: { name, id, photo },
   } = store.getState();
 
   return ids.map((_id) => {
     if (_id === id) {
-      return { id, name, photo, score };
+      return { id, name, photo };
     }
     const conn = selectConnectionById(store.getState(), _id);
     if (conn) {
       return conn;
     } else {
-      return { id: _id, name: 'Stranger', score: 0 };
+      return { id: _id, name: 'Stranger' };
     }
   });
 };
@@ -74,12 +65,6 @@ export const knownMemberIDs = (group) => {
   let knownMemberIDs = group.members.filter((memberId) =>
     selectConnectionById(store.getState(), memberId),
   );
-  if (group.isNew) {
-    // explicitly add founderIDs as they might not have joined yet
-    knownMemberIDs = knownMemberIDs.concat(group.founders);
-    // make sure array is unique
-    knownMemberIDs = [...new Set(knownMemberIDs)];
-  }
   return knownMemberIDs;
 };
 

--- a/BrightID/src/utils/operations.js
+++ b/BrightID/src/utils/operations.js
@@ -5,14 +5,16 @@ import {
   resetOperations,
   updateLinkedContext,
   selectAllOperations,
+  addConnection,
+  updateMemberships
 } from '@/actions';
-import fetchUserInfo from '@/actions/fetchUserInfo';
 import i18next from 'i18next';
 import { checkTasks } from '@/components/Tasks/TasksSlice';
 
 const time_fudge = 2 * 60 * 1000; // trace operations for 2 minutes
 
-const handleOpUpdate = (store, op, state, result) => {
+const handleOpUpdate = (store, op, state, result, api) => {
+  let showDefaultError = false;
   switch (op.name) {
     case 'Link ContextId':
       store.dispatch(
@@ -22,7 +24,6 @@ const handleOpUpdate = (store, op, state, result) => {
           state,
         }),
       );
-
       if (state === 'applied') {
         Alert.alert(
           i18next.t('apps.alert.title.linkSuccess'),
@@ -39,16 +40,59 @@ const handleOpUpdate = (store, op, state, result) => {
           }),
         );
       }
+      break;
 
+    case 'Connect':
+      if (op.id1 != store.getState().user.id) {
+        // ignore other side of dummy test connections
+        break;
+      }
+      if (state === 'applied') {
+        store.dispatch(addConnection({ id: op.id2, status: 'verified' }));
+      } else {
+        api.getProfile(op.id2).then((profile) => {
+          const conn = {
+            id: profile.id,
+            level: profile.level,
+            timestamp: profile.connectedAt,
+            reportReason: profile.reports.find((r) => r.id === op.id1)?.reason
+          };
+          store.dispatch(addConnection(conn));
+        });
+        showDefaultError = true;
+      }
+      break;
+
+    case 'Add Group':
+    case 'Add Membership':
+    case 'Remove Membership':
+      if (state === 'failed') {
+        showDefaultError = true;
+        api.getMemberships(op.id).then((memberships) => {
+          store.dispatch(updateMemberships(memberships));
+        });
+      }
       break;
     default:
+      if (state === 'failed') {
+        showDefaultError = true;
+      }
+  }
+
+  if (showDefaultError) {
+    Alert.alert(
+      i18next.t('common.alert.error'),
+      i18next.t('common.alert.text.failedOp', {
+        name: op.name,
+        message: result.message,
+      }),
+    );
   }
 };
 
 export const pollOperations = async (api) => {
   const operations = selectAllOperations(store.getState());
-
-  let shouldUpdateLocalState = false;
+  let shouldUpdateTasks = false;
   try {
     for (const op of operations) {
       const { state, result } = await api.getOperationState(op.hash);
@@ -68,21 +112,17 @@ export const pollOperations = async (api) => {
         case 'applied':
         case 'failed':
           // op is done, so stop polling for it
-          removeOp = true;
-          handleOpUpdate(store, op, state, result);
-          shouldUpdateLocalState = true;
+          store.dispatch(removeOperation(op.hash));
+          handleOpUpdate(store, op, state, result, api);
+          shouldUpdateTasks = true;
           break;
         default:
           console.log(
             `Op ${op.name} (${op.hash}) has invalid state '${state}'!`,
           );
       }
-      if (removeOp) {
-        store.dispatch(removeOperation(op.hash));
-      }
     }
-    if (shouldUpdateLocalState) {
-      store.dispatch(fetchUserInfo(api));
+    if (shouldUpdateTasks) {
       store.dispatch(checkTasks());
     }
   } catch (err) {


### PR DESCRIPTION
- Removes general `api.getUserInfo` and uses `api.getVerifications`, `api.getMemberships` and `api.getConnections` instead.
- Limits calling updating general redux state using `fetchUserInfo` to the app startup time and updates specific required parts when users navigate different screen or state of operations change.
- Updates invites as part of the notifications update routine.
- Enables users to select arbitrary number of invitees instead of 2 co-founders when they are creating groups.
- Shows an error message on any failing operation.
- Removes all score related codes.
- Renames `Set Signing Key` operation to `Social Recovery`
- Uses v6 for all operations except `Link ContextId` which is deprecated on this version.
- Adds `getGroup`, `getMemberships`, `getInvites`, Removes `getUserInfo` and renames `getUserVerifications` and `getUserProfile` to `getVerifications` and `getProfile`.
- Adds `state` to groups and filter groups that users leave or are dismissed instead of removing them from redux state to prevent missing necessary data if a node return wrong memberships.
- Updates information related to each group like number of members when the group details screen (members list) is opened.
- 