### PR TITLE
fix crash when verifications are undefined

### DIFF
--- a/BrightID/src/components/Apps/AppCard.tsx
+++ b/BrightID/src/components/Apps/AppCard.tsx
@@ -52,9 +52,9 @@ const AppCard = (props: AppInfo) => {
   const { t } = useTranslation();
 
   // does user have all required verifications for this app?
-  const verified = verifications.every((v) =>
-    userVerifications.some((uv) => uv.name === v),
-  );
+  const verified = verifications
+    ? verifications.every((v) => userVerifications.some((uv) => uv.name === v))
+    : false;
   const isLinked = linkedContext && linkedContext.state === 'applied';
   const notSponsored = unusedSponsorships < 1 || !unusedSponsorships;
 


### PR DESCRIPTION
We have 15 reports about the error `com.facebook.react.common.JavascriptException: TypeError: Cannot read property 'every' of undefined` since launching 4.7.0 client. This commit should prevent that from happening.