### PR TITLE
add possible duplicates of a connection to connection details screen

### DIFF
--- a/BrightID/android/app/build.gradle
+++ b/BrightID/android/app/build.gradle
@@ -164,8 +164,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         missingDimensionStrategy 'react-native-camera', 'general'
-        versionCode 39
-        versionName "4.8.0"
+        versionCode 41
+        versionName "4.8.1"
         multiDexEnabled true
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/BrightID/android/app/build.gradle
+++ b/BrightID/android/app/build.gradle
@@ -164,8 +164,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         missingDimensionStrategy 'react-native-camera', 'general'
-        versionCode 41
-        versionName "4.8.1"
+        versionCode 39
+        versionName "4.8.0"
         multiDexEnabled true
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/BrightID/locales/de/translation.json
+++ b/BrightID/locales/de/translation.json
@@ -197,7 +197,8 @@
     "label": {
       "connectionLevel": "Verbindungsstufe",
       "mutualConnections": "Gemeinsame Verbindungen",
-      "mutualGroups": "Gemeinsame Gruppen"
+      "mutualGroups": "Gemeinsame Gruppen",
+      "possibleDuplicates": "Mögliche Duplikate"
     },
     "tags": {
       "connectedAt": "Verbunden {{date}}",

--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -185,7 +185,8 @@
       "connectionLevel": "Connection Level",
       "mutualConnections": "Mutual Connections",
       "mutualGroups": "Mutual Groups",
-      "recoveryConnections": "Recovery Connections"
+      "recoveryConnections": "Recovery Connections",
+      "possibleDuplicates": "Possible Duplicates"
     },
     "tags": {
       "connectedAt": "Connected {{date}}",

--- a/BrightID/locales/es/translation.json
+++ b/BrightID/locales/es/translation.json
@@ -194,7 +194,8 @@
     "label": {
       "connectionLevel": "Nivel de Conexión",
       "mutualConnections": "Conexiones Mutuas",
-      "mutualGroups": "Grupos Mutuos"
+      "mutualGroups": "Grupos Mutuos",
+      "possibleDuplicates": "Posibles Duplicados"
     },
     "tags": {
       "connectedAt": "Conectado {{date}}",

--- a/BrightID/locales/fa/translation.json
+++ b/BrightID/locales/fa/translation.json
@@ -175,7 +175,8 @@
     "label": {
       "connectionLevel": "سطح کانکشن",
       "mutualConnections": "کانکشن های مشترک",
-      "mutualGroups": "گروه های مشترک"
+      "mutualGroups": "گروه های مشترک",
+      "possibleDuplicates": "موارد تکراری احتمالی"
     },
     "tags": {
       "connectedAt": "{{date}} با هم کانکشن زدید",

--- a/BrightID/locales/fr/translation.json
+++ b/BrightID/locales/fr/translation.json
@@ -194,7 +194,8 @@
     "label": {
       "connectionLevel": "Niveau de Connexion",
       "mutualConnections": "Connexions en Commun",
-      "mutualGroups": "Groupes en Commun"
+      "mutualGroups": "Groupes en Commun",
+      "possibleDuplicates": "Doublons Possibles"
     },
     "tags": {
       "connectedAt": "Connecté(e) {{date}}",

--- a/BrightID/locales/hi/translation.json
+++ b/BrightID/locales/hi/translation.json
@@ -193,7 +193,8 @@
     "label": {
       "connectionLevel": "कनेक्शन की लेवल",
       "mutualConnections": "आपसी कनेक्शन",
-      "mutualGroups": "आपसी ग्रुप"
+      "mutualGroups": "आपसी ग्रुप",
+      "possibleDuplicates": "संभावित डुप्लिकेट"
     },
     "tags": {
       "connectedAt": "कनेक्ट {{date}}",

--- a/BrightID/locales/ru/translation.json
+++ b/BrightID/locales/ru/translation.json
@@ -188,7 +188,8 @@
     "label": {
       "connectionLevel": "Уровень подключения",
       "mutualConnections": "Общие подключения",
-      "mutualGroups": "Общие группы"
+      "mutualGroups": "Общие группы",
+      "possibleDuplicates": "Возможные дубликаты"
     },
     "tags": {
       "connectedAt": "Подключено {{date}}",

--- a/BrightID/locales/zh_Hans/translation.json
+++ b/BrightID/locales/zh_Hans/translation.json
@@ -193,7 +193,8 @@
     "label": {
       "connectionLevel": "联系人熟悉程度",
       "mutualConnections": "共同联系人",
-      "mutualGroups": "共同群组"
+      "mutualGroups": "共同群组",
+      "possibleDuplicates": "可能的重复"
     },
     "tags": {
       "connectedAt": "建立联系的 {{date}}",

--- a/BrightID/locales/zh_Hant/translation.json
+++ b/BrightID/locales/zh_Hant/translation.json
@@ -172,7 +172,8 @@
     "label": {
       "connectionLevel": "連接級別",
       "mutualConnections": "互相連接",
-      "mutualGroups": "關聯團隊"
+      "mutualGroups": "關聯團隊",
+      "possibleDuplicates": "可能的重複"
     },
     "tags": {
       "connectedAt": "已連接{{date}}",

--- a/BrightID/src/components/Connections/ConnectionScreen.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreen.tsx
@@ -9,6 +9,9 @@ import {
   View,
   SectionList,
 } from 'react-native';
+import {
+  selectAllConnections,
+} from '@/reducer/connectionsSlice';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import moment from 'moment';
@@ -30,6 +33,9 @@ import { fontSize } from '@/theme/fonts';
 import { connection_levels } from '@/utils/constants';
 import Chevron from '../Icons/Chevron';
 import TrustLevelView from './TrustLevelView';
+import { useSelector } from '@/store';
+import { connectionsSelector } from '@/utils/connectionsSelector';
+import stringSimilarity from '@/utils/stringSimilarity';
 
 /**
  Connection details screen
@@ -65,11 +71,14 @@ function ConnectionScreen(props: Props) {
     loading,
   } = props;
   const navigation = useNavigation();
+  const myConnections = useSelector(selectAllConnections);
 
   const [groupsCollapsed, setGroupsCollapsed] = useState(true);
   const [connectionsCollapsed, setConnectionsCollapsed] = useState(true);
   const [recoveryConnectionsCollapsed, setRecoveryConnectionsCollapsed] =
     useState(true);
+  const [possibleDuplicatesCollapsed, setPossibleDuplicatesCollapsed] = useState(true);
+  const possibleDuplicates = myConnections.filter(conn => stringSimilarity(conn.name, connection.name) >= 0.6 && conn.id != connection.id);
   const { t } = useTranslation();
 
   const toggleSection = (key) => {
@@ -82,6 +91,9 @@ function ConnectionScreen(props: Props) {
         break;
       case 'recoveryConnections':
         setRecoveryConnectionsCollapsed(!recoveryConnectionsCollapsed);
+        break;
+      case 'duplicates':
+        setPossibleDuplicatesCollapsed(!possibleDuplicatesCollapsed);
         break;
     }
   };
@@ -110,6 +122,12 @@ function ConnectionScreen(props: Props) {
         key: 'recoveryConnections',
         numEntries: recoveryConnections.length,
       },
+      {
+        title: t('connectionDetails.label.possibleDuplicates'),
+        data: possibleDuplicatesCollapsed ? [] : possibleDuplicates,
+        key: 'duplicates',
+        numEntries: possibleDuplicates.length,
+      },
     ];
     return data;
   }, [
@@ -120,6 +138,8 @@ function ConnectionScreen(props: Props) {
     mutualGroups,
     recoveryConnectionsCollapsed,
     recoveryConnections,
+    possibleDuplicatesCollapsed,
+    possibleDuplicates
   ]);
 
   const renderSticker = () => {
@@ -327,6 +347,9 @@ function ConnectionScreen(props: Props) {
         break;
       case 'recoveryConnections':
         collapsed = recoveryConnectionsCollapsed;
+        break;
+      case 'duplicates':
+        collapsed = possibleDuplicatesCollapsed;
         break;
     }
     return (

--- a/BrightID/src/components/Connections/ConnectionScreen.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -78,7 +78,10 @@ function ConnectionScreen(props: Props) {
   const [recoveryConnectionsCollapsed, setRecoveryConnectionsCollapsed] =
     useState(true);
   const [possibleDuplicatesCollapsed, setPossibleDuplicatesCollapsed] = useState(true);
-  const possibleDuplicates = myConnections.filter(conn => stringSimilarity(conn.name, connection.name) >= 0.6 && conn.id != connection.id);
+  const [possibleDuplicates, setPossibleDuplicates] = useState([]);
+  useEffect(() => {
+    setPossibleDuplicates(myConnections.filter(conn => stringSimilarity(conn.name, connection.name) >= 0.6 && conn.id != connection.id));
+  }, [myConnections])
   const { t } = useTranslation();
 
   const toggleSection = (key) => {

--- a/BrightID/src/components/Connections/ConnectionScreen.tsx
+++ b/BrightID/src/components/Connections/ConnectionScreen.tsx
@@ -30,7 +30,7 @@ import {
   DARK_GREEN,
 } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
-import { connection_levels } from '@/utils/constants';
+import { connection_levels, POSSIBLE_DUPLICATE_STRING_SIMILARITY_RATE } from '@/utils/constants';
 import Chevron from '../Icons/Chevron';
 import TrustLevelView from './TrustLevelView';
 import { useSelector } from '@/store';
@@ -80,7 +80,12 @@ function ConnectionScreen(props: Props) {
   const [possibleDuplicatesCollapsed, setPossibleDuplicatesCollapsed] = useState(true);
   const [possibleDuplicates, setPossibleDuplicates] = useState([]);
   useEffect(() => {
-    setPossibleDuplicates(myConnections.filter(conn => stringSimilarity(conn.name, connection.name) >= 0.6 && conn.id != connection.id));
+    setPossibleDuplicates(myConnections.filter(
+      conn =>
+        stringSimilarity(conn.name, connection.name) >= POSSIBLE_DUPLICATE_STRING_SIMILARITY_RATE
+        && conn.id != connection.id
+      )
+    );
   }, [myConnections])
   const { t } = useTranslation();
 

--- a/BrightID/src/utils/constants.ts
+++ b/BrightID/src/utils/constants.ts
@@ -17,6 +17,7 @@ export const RECOVERY_COOLDOWN_EXEMPTION = 24 * 60 * 60 * 1000; // 24 hours
 // timestamp can be this far in the future (milliseconds) to accommodate 2 clients clock differences
 export const TIME_FUDGE = 60 * 60 * 1000;
 export const PROFILE_VERSION = 1;
+export const POSSIBLE_DUPLICATE_STRING_SIMILARITY_RATE = 0.6;
 
 // Channel info
 export const CHANNEL_INFO_NAME = 'channelInfo.json';

--- a/BrightID/src/utils/stringSimilarity.ts
+++ b/BrightID/src/utils/stringSimilarity.ts
@@ -1,0 +1,40 @@
+function editDistance(s1: string, s2: string) {
+    s1 = s1.toLowerCase();
+    s2 = s2.toLowerCase();
+    
+    var costs = new Array();
+    for (var i = 0; i <= s1.length; i++) {
+        var lastValue = i;
+        for (var j = 0; j <= s2.length; j++) {
+        if (i == 0)
+            costs[j] = j;
+        else {
+            if (j > 0) {
+            var newValue = costs[j - 1];
+            if (s1.charAt(i - 1) != s2.charAt(j - 1))
+                newValue = Math.min(Math.min(newValue, lastValue),
+                costs[j]) + 1;
+            costs[j - 1] = lastValue;
+            lastValue = newValue;
+            }
+        }
+        }
+        if (i > 0)
+        costs[s2.length] = lastValue;
+    }
+    return costs[s2.length];
+}
+
+export default function stringSimilarity(s1: string, s2: string) {
+    var longer = s1;
+    var shorter = s2;
+    if (s1.length < s2.length) {
+        longer = s2;
+        shorter = s1;
+    }
+    var longerLength = longer.length;
+    if (longerLength == 0) {
+        return 1.0;
+    }
+    return (longerLength - editDistance(longer, shorter)) / longerLength;
+}


### PR DESCRIPTION
I used a string similarity code to figure out if a connection's name is similar to another one and showing possible duplicates of one connection in it's details page. 
https://github.com/BrightID/BrightID/issues/61#issuecomment-679317422