### PR TITLE
wait for submit photo button to be enabled in tests

### DIFF
--- a/BrightID/e2e/testUtils.js
+++ b/BrightID/e2e/testUtils.js
@@ -47,9 +47,13 @@ const addPhoto = async () => {
   await waitFor(element(by.id('addPhoto')))
     .toBeVisible()
     .withTimeout(15000);
-  // create new ID
-  await expect(element(by.id('submitPhoto'))).toExist();
-  await element(by.id('submitPhoto')).tap();
+
+  const submitPhoto = element(by.id('submitPhoto'))
+  await expect(submitPhoto).toExist();
+  // wait for the button to be enabled after setting the photo
+  await new Promise((r) => setTimeout(r, 2000));
+  // submit photo
+  await submitPhoto.tap();
 };
 
 const skipPassword = async () => {


### PR DESCRIPTION
I tried to test the app with the steps that are mentioned in the wiki. However, when the mock client changes to photo in the submit photo page, it tries to tap the "submitPhoto" button immediately, which is disabled and takes some time to get enabled

I tried to find a solution to wait for the button to get enabled but it's still an issue in detox that doesn't have a solution:
https://github.com/wix/detox/issues/246

So, I used a 2-second sleep to wait for the button to get enabled. And now, tests are working.