### PR TITLE
Refactor pending connections

### DIFF
--- a/BrightID/e2e/reconnect.spec.ts
+++ b/BrightID/e2e/reconnect.spec.ts
@@ -1,4 +1,5 @@
-import { by, element, expect } from 'detox';import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { by, element, expect } from 'detox';
+import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
 import {
   createBrightID,
   createFakeConnection,
@@ -18,6 +19,13 @@ describe('Reconnect existing connection', () => {
     beforeAll(async () => {
       // create a fake connection
       await createFakeConnection();
+      // make sure all connections are established
+      await element(by.id('connectionsBtn')).tap();
+      await expectConnectionsScreen();
+      await waitFor(element(by.id('connection-0')))
+        .toExist()
+        .withTimeout(20000);
+      await navigateHome();
     });
 
     beforeEach(async () => {
@@ -94,6 +102,13 @@ describe('Reconnect existing connection', () => {
     beforeAll(async () => {
       // create a fake connection
       await createFakeConnection();
+      // make sure all connections are established
+      await element(by.id('connectionsBtn')).tap();
+      await expectConnectionsScreen();
+      await waitFor(element(by.id('connection-0')))
+        .toExist()
+        .withTimeout(20000);
+      await navigateHome();
       await reconnect(0, false);
     });
 

--- a/BrightID/src/actions/fakeContact.ts
+++ b/BrightID/src/actions/fakeContact.ts
@@ -62,7 +62,7 @@ export const addFakeConnection =
         ],
       );
 
-      const dataObj = {
+      const dataObj: SharedProfile = {
         id: connectId,
         photo,
         name,

--- a/BrightID/src/api/response_types.d.ts
+++ b/BrightID/src/api/response_types.d.ts
@@ -171,6 +171,8 @@ type InviteInfo = {
   data: string;
 };
 
+type Report = { id: string; reportReason: string };
+
 type ProfileInfo = {
   id: string;
   connectionsNum: number;
@@ -180,7 +182,7 @@ type ProfileInfo = {
   recoveryConnections: RecoveryConnection[];
   connectedAt: number;
   createdAt: number;
-  reports: Array<{ id: string; reportReason: string }>;
+  reports: Array<Report>;
   verifications: Verification[];
   signingKeys: string[];
   sponsored: boolean;

--- a/BrightID/src/components/Notifications/PendingConnectionCard.tsx
+++ b/BrightID/src/components/Notifications/PendingConnectionCard.tsx
@@ -13,12 +13,25 @@ import {
 import { fontSize } from '@/theme/fonts';
 import CirclePhoto from '@/components/Helpers/CirclePhoto';
 
-export const PendingConnectionCard = ({ pendingConnections }) => {
+type PendingConnectionCardProps = {
+  pendingConnections: Array<PendingConnection>;
+};
+export const PendingConnectionCard = ({
+  pendingConnections,
+}: PendingConnectionCardProps) => {
   const { navigate } = useNavigation();
   const { t } = useTranslation();
-  const circlePhotos = pendingConnections.map(({ photo }) => ({ uri: photo }));
+  const circlePhotos = pendingConnections.map((pc) => ({
+    uri: pc.pendingConnectionData.sharedProfile.photo,
+  }));
   const firstNames = pendingConnections
-    .map(({ name }) => name.split(' ')[0])
+    .map(
+      ({
+        pendingConnectionData: {
+          sharedProfile: { name },
+        },
+      }) => name.split(' ')[0],
+    )
     .join(', ');
   const navToPending = () => {
     navigate('PendingConnections');

--- a/BrightID/src/components/Onboarding/ImportFlow/thunks/channelUploadThunks.ts
+++ b/BrightID/src/components/Onboarding/ImportFlow/thunks/channelUploadThunks.ts
@@ -53,14 +53,12 @@ export const uploadAllInfoAfter = async (after) => {
     (conn) => conn.timestamp > after,
   );
   for (const conn of connections) {
-    if (conn.timestamp > after) {
-      await uploadConnection({
-        conn,
-        channelApi,
-        aesKey,
-        signingKey,
-      });
-    }
+    await uploadConnection({
+      conn,
+      channelApi,
+      aesKey,
+      signingKey,
+    });
   }
 
   console.log('uploading groups');

--- a/BrightID/src/components/PendingConnections/GroupConnectionScreen.tsx
+++ b/BrightID/src/components/PendingConnections/GroupConnectionScreen.tsx
@@ -16,12 +16,10 @@ import {
   useFocusEffect,
 } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-
 import Svg, { Line } from 'react-native-svg';
-
-import { useSelector } from '@/store';
 import { createSelector } from '@reduxjs/toolkit';
 import Material from 'react-native-vector-icons/MaterialCommunityIcons';
+import { useSelector } from '@/store';
 import { ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE, WIDTH, HEIGHT } from '@/utils/deviceConstants';
 import { fontSize } from '@/theme/fonts';
@@ -54,7 +52,8 @@ const selectGroupConnections = createSelector(
     console.log('calcing pending connections');
     return pendingConnections.filter(
       (pc) =>
-        pc.channelId === channel?.id && pc.id !== channel?.initiatorProfileId,
+        pc.channelId === channel?.id &&
+        pc.profileId !== channel?.initiatorProfileId,
     );
   },
 );
@@ -169,13 +168,13 @@ export const GroupConnectionScreen = () => {
             <TouchableWithoutFeedback
               onPress={() => {
                 navigation.navigate('FullScreenPhoto', {
-                  photo: pc.photo,
+                  photo: pc.pendingConnectionData.sharedProfile.photo,
                   base64: true,
                 });
               }}
             >
               <Image
-                key={pc.id}
+                key={pc.profileId}
                 style={[
                   styles.connectionBubble,
                   {
@@ -183,7 +182,7 @@ export const GroupConnectionScreen = () => {
                     top: bubbleCoords[index]?.top,
                   },
                 ]}
-                source={{ uri: pc.photo }}
+                source={{ uri: pc.pendingConnectionData.sharedProfile.photo }}
               />
             </TouchableWithoutFeedback>
           </>
@@ -239,18 +238,20 @@ export const GroupConnectionScreen = () => {
             },
           ]}
         />
-        {initiator?.photo && (
+        {initiator?.pendingConnectionData.sharedProfile.photo && (
           <TouchableWithoutFeedback // style={styles.cancelButton}
             onPress={() => {
               navigation.navigate('FullScreenPhoto', {
-                photo: initiator.photo,
+                photo: initiator.pendingConnectionData.sharedProfile.photo,
                 base64: true,
               });
             }}
           >
             <Image
               style={styles.groupFounder}
-              source={{ uri: initiator.photo }}
+              source={{
+                uri: initiator.pendingConnectionData.sharedProfile.photo,
+              }}
             />
           </TouchableWithoutFeedback>
         )}

--- a/BrightID/src/components/PendingConnections/PendingConnectionsScreen.tsx
+++ b/BrightID/src/components/PendingConnections/PendingConnectionsScreen.tsx
@@ -46,9 +46,9 @@ export const PendingConnectionsScreen = () => {
     return selectAllUnconfirmedConnections(state);
   });
   // pending connections to display
-  const [pendingConnectionsToDisplay, setPendingConnectionsDisplay] = useState(
-    [],
-  );
+  const [pendingConnectionsToDisplay, setPendingConnectionsDisplay] = useState<
+    Array<PendingConnection>
+  >([]);
   const [loading, setLoading] = useState(true);
   const [activeIndex, setActiveIndex] = useState(0);
   const [onLastIndex, setOnLastIndex] = useState(false);
@@ -141,7 +141,7 @@ export const PendingConnectionsScreen = () => {
     the list should only re render sparingly for performance and continuity
   */
   const PendingConnectionList = useMemo(() => {
-    const renderView = (item, index) => {
+    const renderView = (item: PendingConnection, index: number) => {
       const last = index === pendingConnectionsToDisplay.length - 1;
       const moveToNext = () => {
         /**
@@ -160,7 +160,7 @@ export const PendingConnectionsScreen = () => {
           key={index}
         >
           <PreviewConnectionController
-            pendingConnectionId={item.id}
+            pendingConnectionId={item.profileId}
             moveToNext={moveToNext}
           />
         </View>

--- a/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
+++ b/BrightID/src/components/PendingConnections/PreviewConnectionController.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
-import { useDispatch, useSelector } from '@/store';
 import { InteractionManager, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useDispatch, useSelector } from '@/store';
 import { WHITE } from '@/theme/colors';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import { confirmPendingConnectionThunk } from './actions/pendingConnectionThunks';
@@ -34,7 +34,8 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
     return null;
   }
 
-  let isReconnect = !!pendingConnection.existingConnection;
+  let isReconnect =
+    !!pendingConnection.pendingConnectionData.existingConnection;
   if (pendingConnection.state !== pendingConnection_states.UNCONFIRMED) {
     // Don't display reconnect screen for connections that have just been confirmed
     isReconnect = false;
@@ -45,20 +46,23 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
     moveToNext();
     // wait until after finishes navigation before dispatching confirm action
     InteractionManager.runAfterInteractions(() => {
-      dispatch(confirmPendingConnectionThunk(pendingConnection.id, level, api));
+      dispatch(
+        confirmPendingConnectionThunk(pendingConnection.profileId, level, api),
+      );
     });
   };
 
   const abuseHandler = () => {
     if (isReconnect) {
       navigation.navigate('ReportReason', {
-        connectionId: pendingConnection.existingConnection.id,
+        connectionId:
+          pendingConnection.pendingConnectionData.existingConnection.id,
         reporting: true,
         successCallback: () => {
           // Set pending connection to "CONFIRMED" to indicate it has been handled by the user
           dispatch(
             updatePendingConnection({
-              id: pendingConnection.id,
+              id: pendingConnection.profileId,
               changes: {
                 state: pendingConnection_states.CONFIRMED,
               },
@@ -71,18 +75,22 @@ export const PreviewConnectionController = (props: PreviewConnectionProps) => {
 
   const photoTouchHandler = () => {
     navigation.navigate('FullScreenPhoto', {
-      photo: pendingConnection.photo,
+      photo: pendingConnection.pendingConnectionData.sharedProfile.photo,
       base64: true,
     });
   };
 
-  console.log(`rendering ${pendingConnection.name}`);
+  console.log(
+    `rendering ${pendingConnection.pendingConnectionData.sharedProfile.name}`,
+  );
   return (
     <View style={styles.previewContainer}>
       {isReconnect ? (
         <ReconnectView
           pendingConnection={pendingConnection}
-          existingConnection={pendingConnection.existingConnection}
+          existingConnection={
+            pendingConnection.pendingConnectionData.existingConnection
+          }
           setLevelHandler={setLevelHandler}
           abuseHandler={abuseHandler}
         />

--- a/BrightID/src/components/PendingConnections/PreviewConnectionView.tsx
+++ b/BrightID/src/components/PendingConnections/PreviewConnectionView.tsx
@@ -27,21 +27,26 @@ type PreviewConnectionProps = {
 
 export const PreviewConnectionView = (props: PreviewConnectionProps) => {
   const { t } = useTranslation();
-  const { pendingConnection, setLevelHandler, photoTouchHandler } = props;
+  const {
+    pendingConnection: {
+      state,
+      pendingConnectionData: { sharedProfile, profileInfo },
+    },
+    setLevelHandler,
+    photoTouchHandler,
+  } = props;
   const id = useSelector((state) => state.user.id);
 
-  const userReported = pendingConnection.reports.find(
-    (report) => report.id === id,
-  );
+  const reports = profileInfo?.reports || [];
+
+  const userReported = reports.find((report) => report.id === id);
 
   const reported =
     !userReported &&
-    pendingConnection.reports.length /
-      (pendingConnection.connectionsNum || 1) >=
-      REPORTED_PERCENTAGE;
+    reports.length / (profileInfo?.connectionsNum || 1) >= REPORTED_PERCENTAGE;
 
   let ratingView;
-  switch (pendingConnection.state) {
+  switch (state) {
     case pendingConnection_states.UNCONFIRMED: {
       ratingView = <RatingView setLevelHandler={setLevelHandler} />;
       break;
@@ -88,12 +93,12 @@ export const PreviewConnectionView = (props: PreviewConnectionProps) => {
       );
   }
 
-  const date = moment(pendingConnection.createdAt || Date.now()).fromNow();
+  const date = moment(profileInfo?.createdAt || Date.now()).fromNow();
 
   const connectionBrightId = __DEV__ ? (
     <View>
       <Text testID="connectionBrightId" style={{ fontSize: 6, color: BLACK }}>
-        {pendingConnection.brightId}
+        {sharedProfile.id}
       </Text>
     </View>
   ) : null;
@@ -110,7 +115,7 @@ export const PreviewConnectionView = (props: PreviewConnectionProps) => {
         )}
         <TouchableWithoutFeedback onPress={photoTouchHandler}>
           <Image
-            source={{ uri: pendingConnection.photo }}
+            source={{ uri: sharedProfile.photo }}
             style={styles.photo}
             resizeMode="cover"
             onError={(e) => {
@@ -121,7 +126,7 @@ export const PreviewConnectionView = (props: PreviewConnectionProps) => {
           />
         </TouchableWithoutFeedback>
         <View style={styles.connectNameContainer}>
-          <Text style={styles.connectName}>{pendingConnection.name}</Text>
+          <Text style={styles.connectName}>{sharedProfile.name}</Text>
           <View style={styles.createdContainer}>
             <Text style={styles.createdText}>
               {t('pendingConnections.label.created', { date })}
@@ -131,9 +136,9 @@ export const PreviewConnectionView = (props: PreviewConnectionProps) => {
       </View>
       <View style={styles.countsContainer}>
         <ConnectionStats
-          connectionsNum={pendingConnection.connectionsNum}
-          groupsNum={pendingConnection.groupsNum}
-          mutualConnectionsNum={pendingConnection.mutualConnections.length}
+          connectionsNum={profileInfo?.connectionsNum || 0}
+          groupsNum={profileInfo?.groupsNum || 0}
+          mutualConnectionsNum={profileInfo?.mutualConnections.length || 0}
         />
       </View>
       {userReported && (

--- a/BrightID/src/components/PendingConnections/ReconnectView.tsx
+++ b/BrightID/src/components/PendingConnections/ReconnectView.tsx
@@ -34,6 +34,10 @@ export const ReconnectView = ({
   setLevelHandler,
   abuseHandler,
 }: ReconnectViewProps) => {
+  const {
+    pendingConnectionData: { sharedProfile, profileInfo },
+  } = pendingConnection;
+
   const navigation = useNavigation();
   const [identicalProfile, setIdenticalProfile] = useState(true);
   const [connectionLevel, setConnectionLevel] = useState(
@@ -43,26 +47,23 @@ export const ReconnectView = ({
   const { id } = useSelector((state) => state.user);
   const firstRecoveryTime = useSelector(firstRecoveryTimeSelector);
 
-  const userReported = pendingConnection.reports.find(
-    (report) => report.id === id,
-  );
+  const userReported = profileInfo.reports.find((report) => report.id === id);
 
   const reported =
     !userReported &&
-    pendingConnection.reports.length /
-      (pendingConnection.connectionsNum || 1) >=
+    profileInfo.reports.length / (profileInfo.connectionsNum || 1) >=
       REPORTED_PERCENTAGE;
 
   useEffect(() => {
     const compareProfiles = async () => {
-      if (pendingConnection.name !== existingConnection.name) {
+      if (sharedProfile.name !== existingConnection.name) {
         setIdenticalProfile(false);
         return;
       }
       const existingPhoto = await retrieveImage(
         existingConnection.photo.filename,
       );
-      if (existingPhoto !== pendingConnection.photo) {
+      if (existingPhoto !== sharedProfile.photo) {
         setIdenticalProfile(false);
         return;
       }
@@ -70,7 +71,7 @@ export const ReconnectView = ({
       setIdenticalProfile(true);
     };
     compareProfiles();
-  }, [pendingConnection, existingConnection]);
+  }, [existingConnection, sharedProfile.name, sharedProfile.photo]);
 
   const photoTouchHandler = (photo: string, type: 'base64' | 'file') => {
     navigation.navigate('FullScreenPhoto', {
@@ -104,13 +105,13 @@ export const ReconnectView = ({
         <View style={styles.header} testID="ReconnectScreen">
           <Text style={styles.subheaderText}>
             {t('connections.text.alreadyConnectedWith', {
-              name: pendingConnection.name,
+              name: sharedProfile.name,
             })}
           </Text>
           <Text style={styles.lastConnectedText}>
             {t('connections.tag.lastConnected', {
               date: moment(
-                parseInt(String(pendingConnection.connectedAt), 10),
+                parseInt(String(profileInfo.connectedAt), 10),
               ).fromNow(),
             })}
           </Text>
@@ -118,8 +119,8 @@ export const ReconnectView = ({
         <View style={styles.profiles}>
           <View testID="identicalProfileView" style={styles.profile}>
             <ProfileCard
-              name={pendingConnection.name}
-              photo={pendingConnection.photo}
+              name={sharedProfile.name}
+              photo={sharedProfile.photo}
               photoSize="large"
               photoType="base64"
               photoTouchHandler={photoTouchHandler}
@@ -130,9 +131,9 @@ export const ReconnectView = ({
         </View>
         <View style={styles.countsContainer}>
           <ConnectionStats
-            connectionsNum={pendingConnection.connectionsNum}
-            groupsNum={pendingConnection.groupsNum}
-            mutualConnectionsNum={pendingConnection.mutualConnections.length}
+            connectionsNum={profileInfo.connectionsNum}
+            groupsNum={profileInfo.groupsNum}
+            mutualConnectionsNum={profileInfo.mutualConnections.length}
           />
         </View>
         <View style={styles.connectionLevel}>
@@ -169,7 +170,7 @@ export const ReconnectView = ({
         <View style={styles.header} testID="ReconnectScreen">
           <Text style={styles.subheaderText}>
             {t('connections.text.alreadyConnectedWith', {
-              name: pendingConnection.name,
+              name: sharedProfile.name,
             })}
           </Text>
           <Text style={styles.lastConnectedText}>
@@ -208,8 +209,8 @@ export const ReconnectView = ({
               </Text>
             </View>
             <ProfileCard
-              name={pendingConnection.name}
-              photo={pendingConnection.photo}
+              name={sharedProfile.name}
+              photo={sharedProfile.photo}
               photoSize="small"
               photoType="base64"
               photoTouchHandler={photoTouchHandler}
@@ -220,9 +221,9 @@ export const ReconnectView = ({
         </View>
         <View style={styles.countsContainer}>
           <ConnectionStats
-            connectionsNum={pendingConnection.connectionsNum}
-            groupsNum={pendingConnection.groupsNum}
-            mutualConnectionsNum={pendingConnection.mutualConnections.length}
+            connectionsNum={profileInfo.connectionsNum}
+            groupsNum={profileInfo.groupsNum}
+            mutualConnectionsNum={profileInfo.mutualConnections.length}
           />
         </View>
         <View style={styles.connectionLevel}>

--- a/BrightID/src/components/PendingConnections/actions/channelThunks.ts
+++ b/BrightID/src/components/PendingConnections/actions/channelThunks.ts
@@ -342,7 +342,7 @@ export const encryptAndUploadProfileToChannel =
     const photo = await retrieveImage(filename);
     const profileTimestamp = Date.now();
 
-    const dataObj = {
+    const dataObj: SharedProfile = {
       id,
       photo,
       name,

--- a/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
+++ b/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
@@ -17,103 +17,105 @@ import {
 import { leaveChannel } from '@/components/PendingConnections/actions/channelThunks';
 import { NodeApi } from '@/api/brightId';
 
-export const confirmPendingConnectionThunk = (
-  id: string,
-  level: ConnectionLevel,
-  api: NodeApi,
-) => async (dispatch: dispatch, getState: getState) => {
-  const connection: PendingConnection = selectPendingConnectionById(
-    getState(),
-    id,
-  );
-  // validate pendingConnection state
-  if (connection.state !== pendingConnection_states.UNCONFIRMED) {
-    console.log(`Can't confirm - Connection is in state ${connection.state}`);
-    return;
-  }
-
-  dispatch(
-    updatePendingConnection({
+export const confirmPendingConnectionThunk =
+  (id: string, level: ConnectionLevel, api: NodeApi) =>
+  async (dispatch: dispatch, getState: getState) => {
+    const connection: PendingConnection = selectPendingConnectionById(
+      getState(),
       id,
-      changes: {
-        state: pendingConnection_states.CONFIRMING,
-      },
-    }),
-  );
-
-  const channel = selectChannelById(getState(), connection.channelId);
-  console.log(
-    `confirming connection ${id} in channel ${channel.id} with level '${level}'`,
-  );
-
-  const {
-    user: { id: brightId, backupCompleted },
-  } = getState();
-
-  const connectionTimestamp = Date.now();
-  let reportReason;
-
-  const op = await api.addConnection(
-    brightId,
-    connection.brightId,
-    level,
-    connectionTimestamp,
-    reportReason,
-  );
-  dispatch(addOperation(op));
-
-  if (__DEV__) {
-    // if peer is a fake connection also submit opposite addConnection operation
-    if (connection.secretKey) {
-      const op = await api.addConnection(
-        connection.brightId,
-        brightId,
-        level,
-        connectionTimestamp,
-        reportReason,
-        {
-          id: connection.brightId,
-          secretKey: connection.secretKey,
-        },
-      );
-      dispatch(addOperation(op));
+    );
+    // validate pendingConnection state
+    if (connection.state !== pendingConnection_states.UNCONFIRMED) {
+      console.log(`Can't confirm - Connection is in state ${connection.state}`);
+      return;
     }
-  }
 
-  // save connection photo
-  const filename = await saveImage({
-    imageName: connection.brightId,
-    base64Image: connection.photo,
-  });
+    const {
+      pendingConnectionData: { profileInfo, sharedProfile },
+    } = connection;
 
-  // create established connection from pendingConnection
-  const connectionData: LocalConnectionData = {
-    id: connection.brightId,
-    name: connection.name,
-    connectionDate: connectionTimestamp,
-    photo: { filename },
-    status: 'initiated',
-    notificationToken: connection.notificationToken,
-    secretKey: connection.secretKey,
-    level,
-    socialMedia: connection.socialMedia,
-    verifications: connection.verifications,
+    dispatch(
+      updatePendingConnection({
+        id,
+        changes: {
+          state: pendingConnection_states.CONFIRMING,
+        },
+      }),
+    );
+
+    const channel = selectChannelById(getState(), connection.channelId);
+    console.log(
+      `confirming connection ${id} in channel ${channel.id} with level '${level}'`,
+    );
+
+    const {
+      user: { id: brightId, backupCompleted },
+    } = getState();
+
+    const connectionTimestamp = Date.now();
+    const reportReason = undefined;
+
+    const op = await api.addConnection(
+      brightId,
+      sharedProfile.id,
+      level,
+      connectionTimestamp,
+      reportReason,
+    );
+    dispatch(addOperation(op));
+
+    if (__DEV__) {
+      // if peer is a fake connection also submit opposite addConnection operation
+      if (sharedProfile.secretKey) {
+        const op = await api.addConnection(
+          sharedProfile.id,
+          brightId,
+          level,
+          connectionTimestamp,
+          reportReason,
+          {
+            id: sharedProfile.id,
+            secretKey: sharedProfile.secretKey,
+          },
+        );
+        dispatch(addOperation(op));
+      }
+    }
+
+    // save connection photo
+    const filename = await saveImage({
+      imageName: sharedProfile.id,
+      base64Image: sharedProfile.photo,
+    });
+
+    // create established connection from pendingConnection
+    const connectionData: LocalConnectionData = {
+      id: sharedProfile.id,
+      name: sharedProfile.name,
+      connectionDate: connectionTimestamp,
+      photo: { filename },
+      status: 'initiated',
+      notificationToken: sharedProfile.notificationToken,
+      secretKey: sharedProfile.secretKey,
+      level,
+      socialMedia: sharedProfile.socialMedia,
+      verifications: profileInfo?.verifications || [],
+    };
+
+    dispatch(addConnection(connectionData));
+    dispatch(confirmPendingConnection(connection.profileId));
+
+    // Leave channel if no additional connections are expected
+    if (
+      channel.type === channel_types.SINGLE ||
+      (channel.type === channel_types.STAR &&
+        channel.initiatorProfileId !== channel.myProfileId)
+    ) {
+      dispatch(leaveChannel(channel.id));
+    }
+
+    if (backupCompleted) {
+      await dispatch(backupPhoto(sharedProfile.id, filename));
+      await dispatch(backupUser());
+    }
   };
-
-  dispatch(addConnection(connectionData));
-  dispatch(confirmPendingConnection(connection.id));
-
-  // Leave channel if no additional connections are expected
-  if (
-    channel.type === channel_types.SINGLE ||
-    (channel.type === channel_types.STAR &&
-      channel.initiatorProfileId !== channel.myProfileId)
-  ) {
-    dispatch(leaveChannel(channel.id));
-  }
-
-  if (backupCompleted) {
-    await dispatch(backupPhoto(connection.brightId, filename));
-    await dispatch(backupUser());
-  }
-};

--- a/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
+++ b/BrightID/src/components/PendingConnections/pendingConnectionSlice.ts
@@ -3,21 +3,24 @@ import {
   createEntityAdapter,
   createAsyncThunk,
   createSelector,
+  PayloadAction,
 } from '@reduxjs/toolkit';
 import i18next from 'i18next';
+import { Alert } from 'react-native';
 import {
   removeChannel,
   selectChannelById,
 } from '@/components/PendingConnections/channelSlice';
 import { selectConnectionById } from '@/reducer/connectionsSlice';
 import { decryptData } from '@/utils/cryptoHelper';
-import { Alert } from 'react-native';
 import { PROFILE_VERSION } from '@/utils/constants';
 import { createDeepEqualStringArraySelector } from '@/utils/createDeepEqualStringArraySelector';
 import BrightidError, { USER_NOT_FOUND } from '@/api/brightidError';
 import { NodeApi } from '@/api/brightId';
 
-const pendingConnectionsAdapter = createEntityAdapter<PendingConnection>();
+const pendingConnectionsAdapter = createEntityAdapter<PendingConnection>({
+  selectId: (pendingConnection) => pendingConnection.profileId,
+});
 
 /*
   PendingConnection slice contains all pending connections and their profile info
@@ -42,12 +45,9 @@ export enum pendingConnection_states {
 }
 
 export const newPendingConnection = createAsyncThunk<
-  PendingConnection,
+  PendingConnectionData,
   { channelId: string; profileId: string; api: NodeApi },
-  {
-    dispatch: Dispatch;
-    state: State;
-  }
+  { state: State }
 >(
   'pendingConnections/newPendingConnection',
   async ({ channelId, profileId, api }, { getState }) => {
@@ -65,26 +65,29 @@ export const newPendingConnection = createAsyncThunk<
       dataId: profileId,
     });
 
-    const decryptedObj = decryptData(profileData, channel.aesKey);
+    const sharedProfile = decryptData(
+      profileData,
+      channel.aesKey,
+    ) as SharedProfile;
 
     // compare profile version
     if (
-      decryptedObj.version === undefined || // very old client version
-      decryptedObj.version < PROFILE_VERSION // old client version
+      sharedProfile.version === undefined || // very old client version
+      sharedProfile.version < PROFILE_VERSION // old client version
     ) {
       // other user needs to update his client
       const msg = i18next.t('pendingConnection.alert.text.otherOutdated', {
-        name: `${decryptedObj.name}`,
+        name: `${sharedProfile.name}`,
       });
       Alert.alert(
         i18next.t('pendingConnection.alert.title.connectionImpossible'),
         msg,
       );
       throw new Error(msg);
-    } else if (decryptedObj.version > PROFILE_VERSION) {
+    } else if (sharedProfile.version > PROFILE_VERSION) {
       // I need to update my client
       const msg = i18next.t('pendingConnection.alert.text.localOutdated', {
-        name: `${decryptedObj.name}`,
+        name: `${sharedProfile.name}`,
       });
       Alert.alert(
         i18next.t('pendingConnection.alert.title.connectionImpossible'),
@@ -95,48 +98,40 @@ export const newPendingConnection = createAsyncThunk<
     // Is this brightID already in the list of unconfirmed pending connections? Can happen if the same user joins a
     // channel multiple times (e.g. if users app crashed)
     const alreadyPending = selectAllUnconfirmedConnections(getState()).find(
-      (pc) => decryptedObj.id === pc.brightId,
+      (pc) => sharedProfile.id === pc.pendingConnectionData.sharedProfile.id,
     );
     if (alreadyPending) {
       throw new Error(
-        `PendingConnection ${profileId}: BrightId ${decryptedObj.id} is already existing.`,
+        `PendingConnection ${profileId}: BrightId ${sharedProfile.id} is already existing.`,
       );
     }
 
-    decryptedObj.myself = decryptedObj.id === getState().user.id;
-    let connectionInfo: Partial<UserProfileRes['data']> & {
-      existingConnection?: Connection;
-    } = {};
+    let profileInfo: ProfileInfo;
     try {
-      connectionInfo = await api.getProfile(decryptedObj.id);
+      profileInfo = await api.getProfile(sharedProfile.id);
     } catch (err) {
       if (err instanceof BrightidError && err.errorNum === USER_NOT_FOUND) {
-        // this must be a new user not yet existing on backend. Return empty object.
-        connectionInfo = {
-          connectionsNum: 0,
-          groupsNum: 0,
-          mutualConnections: [],
-          mutualGroups: [],
-          createdAt: 0,
-          connectedAt: 0,
-          verifications: [],
-          reports: [],
-          existingConnection: undefined,
-        };
+        // this must be a new user not yet existing on backend.
       } else {
         throw err;
       }
     }
     // Is this a known connection reconnecting?
-    connectionInfo.existingConnection = selectConnectionById(
+    const existingConnection = selectConnectionById(
       getState(),
-      decryptedObj.id,
+      sharedProfile.id,
     );
 
-    if (connectionInfo.existingConnection) {
-      console.log(`${decryptedObj.id} exists.`);
+    if (existingConnection) {
+      console.log(`${sharedProfile.id} exists.`);
     }
-    return { ...connectionInfo, ...decryptedObj };
+    const pendingConnectionData: PendingConnectionData = {
+      sharedProfile,
+      profileInfo,
+      existingConnection,
+      myself: sharedProfile.id === getState().user.id,
+    };
+    return pendingConnectionData;
   },
 );
 
@@ -153,7 +148,7 @@ const pendingConnectionsSlice = createSlice({
     removePendingConnection: pendingConnectionsAdapter.removeOne,
     updatePendingConnection: pendingConnectionsAdapter.updateOne,
     removeAllPendingConnections: pendingConnectionsAdapter.removeAll,
-    confirmPendingConnection(state, action) {
+    confirmPendingConnection(state, action: PayloadAction<string>) {
       const id = action.payload;
       state = pendingConnectionsAdapter.updateOne(state, {
         id,
@@ -171,7 +166,7 @@ const pendingConnectionsSlice = createSlice({
 
         // Add pending connection in DOWNLOADING state.
         state = pendingConnectionsAdapter.addOne(state, {
-          id: action.meta.arg.profileId,
+          profileId: action.meta.arg.profileId,
           channelId: action.meta.arg.channelId,
           state: pendingConnection_states.DOWNLOADING,
         });
@@ -188,57 +183,17 @@ const pendingConnectionsSlice = createSlice({
           },
         });
       })
-      .addCase(newPendingConnection.fulfilled, (state, action) => {
-        // thunk argument is available via action.meta.arg:
-        const { profileId } = action.meta.arg;
+      .addCase(newPendingConnection.fulfilled, (state, { meta, payload }) => {
+        // thunk arguments are available via action.meta.arg:
+        const { profileId } = meta.arg;
 
         // data returned by thunk is available via action.payload:
-        const {
-          id: brightId,
-          name,
-          photo,
-          profileTimestamp,
-          initiator,
-          connectionsNum,
-          groupsNum,
-          mutualConnections = [],
-          mutualGroups = [],
-          createdAt,
-          connectedAt,
-          reports = [],
-          verifications = [],
-          notificationToken,
-          socialMedia = [],
-          existingConnection,
-        } = action.payload;
-
-        const changes: PendingConnection = {
-          state: action.payload.myself
+        const changes: Partial<PendingConnection> = {
+          state: payload.myself
             ? pendingConnection_states.MYSELF
             : pendingConnection_states.UNCONFIRMED,
-          brightId,
-          name,
-          photo,
-          profileTimestamp,
-          initiator,
-          connectionsNum,
-          groupsNum,
-          mutualConnections,
-          mutualGroups,
-          createdAt,
-          connectedAt,
-          reports,
-          verifications,
-          notificationToken,
-          socialMedia,
-          existingConnection,
+          pendingConnectionData: payload,
         };
-
-        // add secret key if dev
-        if (__DEV__) {
-          const { secretKey } = action.payload;
-          changes.secretKey = secretKey;
-        }
 
         // Perform the update in redux
         state = pendingConnectionsAdapter.updateOne(state, {
@@ -294,22 +249,30 @@ export const selectPendingConnectionByBrightId = createSelector(
     This array is created dynamically and will be a new object with each invocation. Therefore
     we have to use deep equality check
  */
-export const selectAllPendingConnectionsByChannelIds = createDeepEqualStringArraySelector(
-  selectAllPendingConnections,
-  (_, channelIds: string[]) => channelIds,
-  (pendingConnections, channelIds) => {
-    console.log(`selectAllPendingConnectionsByChannelIds ${channelIds}...`);
-    return pendingConnections.filter((pc) => channelIds.includes(pc.channelId));
-  },
-);
-export const selectAllUnconfirmedConnectionsByChannelIds = createDeepEqualStringArraySelector(
-  selectAllUnconfirmedConnections,
-  (_, channelIds: string[]) => channelIds,
-  (pendingConnections, channelIds) => {
-    console.log(`selectAllUnconfirmedConnectionsByChannelIds ${channelIds}...`);
-    return pendingConnections.filter((pc) => channelIds.includes(pc.channelId));
-  },
-);
+export const selectAllPendingConnectionsByChannelIds =
+  createDeepEqualStringArraySelector(
+    selectAllPendingConnections,
+    (_, channelIds: string[]) => channelIds,
+    (pendingConnections, channelIds) => {
+      console.log(`selectAllPendingConnectionsByChannelIds ${channelIds}...`);
+      return pendingConnections.filter((pc) =>
+        channelIds.includes(pc.channelId),
+      );
+    },
+  );
+export const selectAllUnconfirmedConnectionsByChannelIds =
+  createDeepEqualStringArraySelector(
+    selectAllUnconfirmedConnections,
+    (_, channelIds: string[]) => channelIds,
+    (pendingConnections, channelIds) => {
+      console.log(
+        `selectAllUnconfirmedConnectionsByChannelIds ${channelIds}...`,
+      );
+      return pendingConnections.filter((pc) =>
+        channelIds.includes(pc.channelId),
+      );
+    },
+  );
 
 // export actions
 

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -89,6 +89,17 @@ declare global {
     initiatorProfileId: string;
   };
 
+  type SharedProfile = {
+    id: string;
+    photo: string;
+    name: string;
+    socialMedia?: Array<SocialMedia>;
+    profileTimestamp: number;
+    secretKey?: string;
+    notificationToken?: string;
+    version: number;
+  };
+
   type Photo = {
     filename: string;
   };
@@ -128,32 +139,32 @@ declare global {
 
   type PendingConnectionState = keyof typeof pendingConnection_states;
 
-  type PendingConnection = Partial<{
-    id: string;
-    channelId: string;
-    brightId: string;
-    name: string;
-    photo: string;
-    notificationToken: string;
-    score: number;
-    state: PendingConnectionState;
-    verifications: Verification[];
-    connectionsNum: number;
-    reports: Array<{ id: string; reportReason: string }>;
-    connectedAt: number;
-    groupsNum: number;
-    mutualConnections: string[];
-    existingConnection: Connection;
-    socialMedia: SocialMedia[];
-    mutualGroups: string[];
-    createdAt: number;
-    profileTimestamp: number;
-    initiator: string;
-    myself?: boolean;
-    secretKey?: string;
-  }>;
+  /**
+   * PendingConnectionData contains all available info about a pending connection
+   * - existingConnection, if there already is a connection to this user
+   * - sharedProfile: The connection data that was shared via channel
+   * - profileInfo: The connection data that was obtained via brightID node API
+   */
+  type PendingConnectionData = {
+    existingConnection?: Connection;
+    sharedProfile: SharedProfile;
+    profileInfo?: ProfileInfo;
+    notificationToken?: string;
+    myself: boolean;
+  };
 
-  type PendingConnectionsState = EntityState<PendingConnection>;
+  /**
+   * Pending connection is made of
+   * - identifier (channelId, profileId)
+   * - state
+   * The actual connection data is downloaded from a channel and stored in pendingConnectionData.
+   */
+  type PendingConnection = {
+    profileId: string;
+    channelId: string;
+    state: PendingConnectionState;
+    pendingConnectionData?: PendingConnectionData;
+  };
 
   type RecoveryData = {
     publicKey: string;


### PR DESCRIPTION
Improve code maintanability by splitting the huge pendingConnection object/type, to have a better view which information is obtained from where.
