### PR TITLE
Sync linked apps when importing BrightID to another device.

### DIFF
--- a/BrightID/e2e/importAccount.spec.ts
+++ b/BrightID/e2e/importAccount.spec.ts
@@ -9,6 +9,7 @@ import {
   createBrightID,
   createFakeConnection,
   createGroup,
+  expectAppsScreen,
   expectConnectionsScreen,
   expectHomescreen,
   getGroupKeys,
@@ -20,7 +21,11 @@ import { NodeApi } from '@/api/brightId';
 import { b64ToUrlSafeB64, hash } from '@/utils/encoding';
 import { loadRecoveryData } from '@/utils/recovery';
 import { encryptData } from '@/utils/cryptoHelper';
-import { uploadConnection, uploadGroup } from '@/utils/channels';
+import {
+  uploadConnection,
+  uploadContextInfo,
+  uploadGroup,
+} from '@/utils/channels';
 import { IMPORT_PREFIX } from '@/utils/constants';
 
 const apiUrl = 'http://test.brightid.org';
@@ -48,6 +53,35 @@ describe('Import BrightID', () => {
   const fakeConnectionIds: Array<string> = [];
   const groupNames = ['Group one', 'Group two'];
   let groupKeys: Array<{ id: string; aesKey: string }> = [];
+  const apps: { appId: string; contextInfo: ContextInfo }[] = [
+    {
+      appId: 'ethereum',
+      contextInfo: {
+        context: 'ethereum',
+        contextId: '0xB0008ADAFF0DDC5D03652944D28A0F246E5D46A3',
+        dateAdded: 1648459346910,
+        state: 'applied',
+      },
+    },
+    {
+      appId: 'Gitcoin',
+      contextInfo: {
+        context: 'Gitcoin',
+        contextId: '0x1CF62DC276BC71AFC700E4DB9BA7B932F6DB3621',
+        dateAdded: 1648463194129,
+        state: 'applied',
+      },
+    },
+    {
+      appId: '1hive',
+      contextInfo: {
+        context: '1hive',
+        contextId: '0x82978C22A3FF7AF9276AC0FA4D48DD8FE2C123DF',
+        dateAdded: 1648463298792,
+        state: 'applied',
+      },
+    },
+  ];
 
   describe(`Prepare BrightID to be imported`, () => {
     afterAll(async () => {
@@ -219,6 +253,17 @@ describe('Import BrightID', () => {
         });
       }
 
+      // upload ContextInfos
+      for (const app of apps) {
+        await uploadContextInfo({
+          contextInfo: app.contextInfo,
+          channelApi,
+          aesKey,
+          signingKey,
+          prefix: IMPORT_PREFIX,
+        });
+      }
+
       // upload "completed" flag
       await channelApi.upload({
         channelId,
@@ -227,6 +272,20 @@ describe('Import BrightID', () => {
         )}`,
         data: 'completed',
       });
+    });
+
+    it('should import uploaded apps data', async () => {
+      // check that all imported linked Context show app as linked
+      for (const app of apps) {
+        await expectHomescreen();
+        await element(by.id('appsBtn')).tap();
+        await expectAppsScreen();
+        await waitFor(element(by.id(`Linked_${app.appId}`)))
+          .toBeVisible()
+          .whileElement(by.id('appsList'))
+          .scroll(50, 'down');
+        await navigateHome();
+      }
     });
 
     it('should import uploaded connections data', async () => {
@@ -302,8 +361,6 @@ describe('Import BrightID', () => {
 
       await navigateHome();
     });
-
-    test.todo('should import uploaded apps data');
   });
 });
 

--- a/BrightID/src/components/Onboarding/ImportFlow/thunks/channelDownloadThunks.ts
+++ b/BrightID/src/components/Onboarding/ImportFlow/thunks/channelDownloadThunks.ts
@@ -49,7 +49,7 @@ export const downloadContextInfo =
       }
       return contextInfoDataIds.length;
     } catch (err) {
-      console.error(`downloadingBlindSigs: ${err.message}`);
+      console.error(`downloadContextInfo error: ${err.message}`);
     }
   };
 

--- a/BrightID/src/components/Onboarding/ImportFlow/thunks/channelThunks.ts
+++ b/BrightID/src/components/Onboarding/ImportFlow/thunks/channelThunks.ts
@@ -11,6 +11,7 @@ import {
 import {
   checkCompletedFlags,
   downloadBlindSigs,
+  downloadContextInfo,
   downloadUserInfo,
 } from './channelDownloadThunks';
 import { uploadAllInfoAfter, uploadDeviceInfo } from './channelUploadThunks';
@@ -132,6 +133,7 @@ export const checkImportChannel =
     await dispatch(downloadUserInfo({ channelApi, dataIds }));
     await dispatch(downloadConnections({ channelApi, dataIds }));
     await dispatch(downloadGroups({ channelApi, dataIds }));
+    await dispatch(downloadContextInfo({ channelApi, dataIds }));
     if (!isPrimaryDevice) {
       await dispatch(downloadBlindSigs({ channelApi, dataIds }));
     }

--- a/BrightID/src/components/Onboarding/ImportFlow/thunks/channelUploadThunks.ts
+++ b/BrightID/src/components/Onboarding/ImportFlow/thunks/channelUploadThunks.ts
@@ -3,11 +3,12 @@ import { b64ToUrlSafeB64 } from '@/utils/encoding';
 import { encryptData } from '@/utils/cryptoHelper';
 import { retrieveImage } from '@/utils/filesystem';
 import { selectAllConnections } from '@/reducer/connectionsSlice';
-import { selectAllSigs } from '@/reducer/appsSlice';
+import { selectAllLinkedContexts, selectAllSigs } from '@/reducer/appsSlice';
 import ChannelAPI from '@/api/channelService';
 import {
   uploadBlindSig,
   uploadConnection,
+  uploadContextInfo,
   uploadGroup,
 } from '@/utils/channels';
 import { IMPORT_PREFIX } from '@/utils/constants';
@@ -71,6 +72,21 @@ export const uploadAllInfoAfter = async (after) => {
         signingKey,
       });
     }
+  }
+
+  console.log('uploading linked contexts');
+  const linkedContexts = selectAllLinkedContexts(store.getState()).filter(
+    (linkedContext) =>
+      linkedContext.dateAdded > after && linkedContext.state === 'applied',
+  );
+  for (const contextInfo of linkedContexts) {
+    await uploadContextInfo({
+      contextInfo,
+      channelApi,
+      aesKey,
+      signingKey,
+      prefix: IMPORT_PREFIX,
+    });
   }
 
   console.log('uploading blind sigs');

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test_disabled.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recovery.test_disabled.ts
@@ -5,7 +5,7 @@ import ChannelAPI from '@/api/channelService';
 import { hash, uInt8ArrayToB64, b64ToUrlSafeB64 } from '@/utils/encoding';
 import { setupRecovery } from './recoveryThunks';
 import { createChannel, checkChannel } from './channelThunks';
-import { uploadSig, uploadConnection } from './channelUploadThunks';
+import { uploadSig } from './channelUploadThunks';
 import { initialState } from '../recoveryDataSlice';
 
 const FIFTEEN_MINUTES = 900000;

--- a/BrightID/src/utils/channels.ts
+++ b/BrightID/src/utils/channels.ts
@@ -256,3 +256,33 @@ export const uploadBlindSig = async ({
     console.error(`uploadBlindSig: ${err.message}`);
   }
 };
+
+export const uploadContextInfo = async ({
+  contextInfo,
+  channelApi,
+  aesKey,
+  signingKey,
+  prefix,
+}: {
+  contextInfo: ContextInfo;
+  channelApi: ChannelAPI;
+  aesKey: string;
+  signingKey: string;
+  prefix: string;
+}) => {
+  try {
+    const encrypted = encryptData(contextInfo, aesKey);
+    console.log(
+      `Posting ContextInfo: ${contextInfo.context} - ${contextInfo.contextId}...`,
+    );
+    await channelApi.upload({
+      channelId: hash(aesKey),
+      data: encrypted,
+      dataId: `${prefix}contextInfo_${hash(
+        contextInfo.context,
+      )}:${b64ToUrlSafeB64(signingKey)}`,
+    });
+  } catch (err) {
+    console.error(`uploadContextInfo: ${err.message}`);
+  }
+};

--- a/BrightID/types.d.ts
+++ b/BrightID/types.d.ts
@@ -34,7 +34,7 @@ declare global {
     context: string;
     contextId: string;
     dateAdded: number;
-    state: string;
+    state: 'pending' | 'applied' | 'failed';
   };
 
   type SigInfo = {


### PR DESCRIPTION
fixes #966

This only takes care of v5 linked contexts, not apps using v6 blind signatures.