### PR TITLE
Always use `postTimestamp` property for deciding if an operation is expired.

### DIFF
--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -72,6 +72,24 @@ export class NodeApi {
     }
   }
 
+  async submitOp(signedOp: NodeOps, message: string): Promise<SubmittedOp> {
+    // post to node and check result
+    const res = await this.api.post<OperationPostRes, ErrRes>(
+      `/operations`,
+      signedOp,
+    );
+    NodeApi.throwOnError(res);
+
+    // posted successfully. Add hash and postTimestamp to op.
+    const submittedOp = signedOp as SubmittedOp;
+    submittedOp.hash = NodeApi.checkHash(
+      res as ApiOkResponse<OperationPostRes>,
+      message,
+    );
+    submittedOp.postTimestamp = Date.now();
+    return submittedOp;
+  }
+
   requiresCredentials() {
     if (this.id === undefined || this.secretKey === undefined) {
       throw new Error('Missing API credentials');
@@ -107,16 +125,7 @@ export class NodeApi {
     const message = stringify(op);
     console.log(`Connect message: ${message}`);
     op.sig1 = uInt8ArrayToB64(nacl.sign.detached(strToUint8Array(message), sk));
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async createGroup(groupId: string, url: string, type: string) {
@@ -138,16 +147,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async dismiss(dismissee: string, group: string) {
@@ -168,16 +168,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async invite(invitee: string, group: string, data: string) {
@@ -199,16 +190,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async addAdmin(newAdmin: string, group: string) {
@@ -229,17 +211,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async deleteGroup(group: string) {
@@ -259,16 +231,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async joinGroup(group: string, fakeUser?: FakeUser) {
@@ -298,16 +261,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async leaveGroup(group: string) {
@@ -327,16 +281,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async socialRecovery(params: {
@@ -361,17 +306,7 @@ export class NodeApi {
     op.id2 = params.id2;
     op.sig1 = params.sig1;
     op.sig2 = params.sig2;
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    op.postTimestamp = Date.now();
-    return op;
+    return this.submitOp(op, message);
   }
 
   async addSigningKey(signingKey: string) {
@@ -391,16 +326,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async removeSigningKey(signingKey: string) {
@@ -420,16 +346,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      `/operations`,
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async linkContextId(context: string, contextId: string) {
@@ -450,17 +367,7 @@ export class NodeApi {
     op.sig = uInt8ArrayToB64(
       nacl.sign.detached(strToUint8Array(message), this.secretKey),
     );
-    const api = create({
-      baseURL: `${this.baseUrl}/brightid/v5`,
-      headers: { 'Cache-Control': 'no-cache' },
-    });
-    const res = await api.post<OperationPostRes, ErrRes>(`/operations`, op);
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async getGroup(id: string) {
@@ -588,16 +495,7 @@ export class NodeApi {
       v,
     };
     const message = stringify(op);
-    const res = await this.api.post<OperationPostRes, ErrRes>(
-      '/operations',
-      op,
-    );
-    NodeApi.throwOnError(res);
-    op.hash = NodeApi.checkHash(
-      res as ApiOkResponse<OperationPostRes>,
-      message,
-    );
-    return op;
+    return this.submitOp(op, message);
   }
 
   async getSponsorShip(appUserId: string) {

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -382,6 +382,7 @@ export class NodeApi {
       res as ApiOkResponse<OperationPostRes>,
       message,
     );
+    submittedOp.postTimestamp = Date.now();
     return submittedOp;
   }
 

--- a/BrightID/src/api/operation_types.d.ts
+++ b/BrightID/src/api/operation_types.d.ts
@@ -13,13 +13,19 @@ type NodeOps =
   | LinkContextIdOp
   | RemoveGroupOp
   | RemoveMembershipOp
-  | SocialRecoveryOp;
+  | RemoveSigningKeyOp
+  | SocialRecoveryOp
+  | SpendSponsorshipOp;
+
+type SubmittedOp = NodeOps & {
+  hash: string;
+  postTimestamp: number; // when was op submitted to node API
+};
 
 type BaseOp = {
   apiUrl?: string;
   v: number;
-  hash?: string;
-  timestamp: number;
+  timestamp: number; // when was op created and signed
 };
 
 type AddAdminOp = BaseOp & {
@@ -105,7 +111,6 @@ type SocialRecoveryOp = BaseOp & {
   id2?: string;
   sig1?: string;
   sig2?: string;
-  postTimestamp?: number;
 };
 
 type SpendSponsorshipOp = BaseOp & {

--- a/BrightID/src/reducer/operationsSlice.ts
+++ b/BrightID/src/reducer/operationsSlice.ts
@@ -81,11 +81,14 @@ export const selectOutdatedOperations = createSelector(
   (operations) => {
     const now = Date.now();
     return operations
-      .filter(
-        (op) =>
+      .filter((op) => {
+        // prefer postTimestamp for calculation but use timestamp as fallback solution
+        const timestamp = op.postTimestamp || op.timestamp;
+        return (
           outdatedStates.includes(op.state) &&
-          now - op.timestamp > LOCAL_OPERATION_KEEP_THRESHOLD,
-      )
+          now - timestamp > LOCAL_OPERATION_KEEP_THRESHOLD
+        );
+      })
       .map((op) => op.hash);
   },
 );

--- a/BrightID/src/reducer/operationsSlice.ts
+++ b/BrightID/src/reducer/operationsSlice.ts
@@ -9,7 +9,7 @@ import {
   operation_states,
 } from '@/utils/constants';
 
-export type Operation = NodeOps & {
+export type Operation = SubmittedOp & {
   state: typeof operation_states[keyof typeof operation_states];
 };
 
@@ -23,7 +23,7 @@ const operationsSlice = createSlice({
   reducers: {
     addOperation: {
       reducer: operationsAdapter.addOne,
-      prepare: (operation: NodeOps) => {
+      prepare: (operation: SubmittedOp) => {
         return {
           payload: {
             ...operation,

--- a/BrightID/src/utils/operations.ts
+++ b/BrightID/src/utils/operations.ts
@@ -135,14 +135,8 @@ export const pollOperations = async (api) => {
           shouldUpdateTasks = true;
         }
       } else {
-        let t = op.timestamp;
-        if (op.name === 'Social Recovery') {
-          // "postTimestamp" is set on "Social Recovery" operation because "timestamp"
-          // does not represent posting time.
-          t = op.postTimestamp || op.timestamp;
-        }
         // stop polling for op if trace time is expired
-        if (t + OPERATION_TRACE_TIME < Date.now()) {
+        if (op.postTimestamp + OPERATION_TRACE_TIME < Date.now()) {
           store.dispatch(
             updateOperation({
               id: op.hash,

--- a/BrightID/src/utils/operations.ts
+++ b/BrightID/src/utils/operations.ts
@@ -136,7 +136,10 @@ export const pollOperations = async (api) => {
         }
       } else {
         // stop polling for op if trace time is expired
-        if (op.postTimestamp + OPERATION_TRACE_TIME < Date.now()) {
+        if (
+          (op.postTimestamp || op.timestamp) + OPERATION_TRACE_TIME <
+          Date.now()
+        ) {
           store.dispatch(
             updateOperation({
               id: op.hash,


### PR DESCRIPTION
Changes:
- Reduce duplicate code in brightID api by adding `submitOp` function
- Add `postTimestamp` to all operations and set it to the timestamp when operation gets submitted to node api
- Always use postTimestamp when dealing with trace time

Fixes #993 