### PR TITLE
enable soulbound apps to use v6 sponsorship model

### DIFF
--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -64,6 +64,7 @@
       "text": {
         "blindSigAlreadyLinked": "You are already linked with {{app}} with id {{appUserId}}",
         "blindSigAlreadyLinkedDifferent": "You are trying to link with {{app}} using {{appUserId}}. You are already linked with {{app}} with different id {{previousAppUserIds}}. This may lead to problems using the app.",
+        "duplicateAppUserId": "The id {{appUserId}} is used by another user to get sponsored before.",
         "checkWebsite": "To find out more about {{name}}, check out their website!",
         "invalidApp": "{{app}} is not a valid app!",
         "invalidContext": "{{context}} is not a valid context!",

--- a/BrightID/src/api/brightId.ts
+++ b/BrightID/src/api/brightId.ts
@@ -514,7 +514,7 @@ export class NodeApi {
     return this.submitOp(op, message);
   }
 
-  async getSponsorShip(appUserId: string) {
+  async getSponsorship(appUserId: string) {
     const res = await this.api.get<SponsorshipRes, ErrRes>(
       `/sponsorships/${appUserId}`,
     );

--- a/BrightID/src/api/response_types.d.ts
+++ b/BrightID/src/api/response_types.d.ts
@@ -131,6 +131,7 @@ type AppInfo = {
   sponsorPublicKey?: string;
   nodeUrl?: string;
   callbackUrl?: string;
+  soulbound: boolean;
 };
 
 type OperationInfo = OperationState & {

--- a/BrightID/src/components/Apps/AppsScreen.tsx
+++ b/BrightID/src/components/Apps/AppsScreen.tsx
@@ -25,6 +25,7 @@ import { fontSize } from '@/theme/fonts';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import AppCard from './AppCard';
 import { handleV5App, handleV6App } from './model';
+import { AppsRoute } from '@/components/Apps/types';
 
 export const AppsScreen = () => {
   const dispatch = useDispatch();

--- a/BrightID/src/components/Apps/AppsScreen.tsx
+++ b/BrightID/src/components/Apps/AppsScreen.tsx
@@ -24,7 +24,7 @@ import {
 import { fontSize } from '@/theme/fonts';
 import { NodeApiContext } from '@/components/NodeApiGate';
 import AppCard from './AppCard';
-import { handleAppContext, handleBlindSigApp } from './model';
+import { handleV5App, handleV6App } from './model';
 
 export const AppsScreen = () => {
   const dispatch = useDispatch();
@@ -56,11 +56,13 @@ export const AppsScreen = () => {
       });
   }, [api, dispatch]);
 
-  const handleDeepLink = useCallback(() => {
+  const handleV5DeepLink = useCallback(() => {
     const context = route.params?.context;
+    const isValidApp = any(propEq('id', context))(apps);
     const isValidContext = any(propEq('context', context))(apps);
-    if (isValidContext) {
-      handleAppContext(route.params);
+    // legacy apps send context in the deep link but soulbound apps send app
+    if (isValidApp || isValidContext) {
+      handleV5App(route.params, setSponsoringApp, api);
     } else {
       Alert.alert(
         t('apps.alert.title.invalidContext'),
@@ -73,14 +75,13 @@ export const AppsScreen = () => {
       context: '',
       contextId: '',
     });
-  }, [navigation, route.params, apps, t]);
+  }, [navigation, route.params, apps, api, t]);
 
-  const handleAppDeepLink = useCallback(() => {
+  const handleV6DeepLink = useCallback(() => {
     const appId = route.params?.context;
     const appInfo = find(propEq('id', appId))(apps) as AppInfo;
-
     if (api && appInfo && appInfo.usingBlindSig) {
-      handleBlindSigApp(route.params, setSponsoringApp, api);
+      handleV6App(route.params, setSponsoringApp, api);
     } else {
       Alert.alert(
         t('apps.alert.title.invalidApp'),
@@ -96,11 +97,11 @@ export const AppsScreen = () => {
 
   useEffect(() => {
     if (apps.length > 0 && route.params?.baseUrl) {
-      handleDeepLink();
+      handleV5DeepLink();
     } else if (apps.length > 0 && route.params?.context) {
-      handleAppDeepLink();
+      handleV6DeepLink();
     }
-  }, [apps, handleDeepLink, handleAppDeepLink, route.params]);
+  }, [apps, handleV5DeepLink, handleV6DeepLink, route.params]);
 
   const AppStatus = () => {
     let msg: string, waiting: boolean;

--- a/BrightID/src/reducer/userSlice.ts
+++ b/BrightID/src/reducer/userSlice.ts
@@ -27,6 +27,8 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
+    // v5 sponsored is not used anymore and should be merged by v6 into a single sponsored status
+    // after most users loaded their v5 sponsored status from nodes by opening their apps
     setIsSponsored(state, action) {
       state.isSponsored = action.payload;
       state.updateTimestamps.isSponsored = Date.now();


### PR DESCRIPTION

- Prevents sponsorship for v6 and soulbound apps if the `appUserId` is used by another user to get sponsored before. This prevents apps to use sponsored `appUserId`s of other apps for not sponsored users to bypass the sponsorship system.
- Enables v5 soulbound apps to use the v6 sponsorship model.