### PR TITLE
fix bugs in updating blind sigs

### DIFF
--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -88,7 +88,8 @@
       "noApps": "No Apps",
       "notSponsored": "You're not sponsored.\nPlease find an app below to sponsor you.",
       "pendingLink": "Linking your account in {{context}} to your BrightID…",
-      "sponsoring": "{{app}} is sponsoring you…"
+      "sponsoring": "{{app}} is sponsoring you…",
+      "sigsUpdating": "Updating blind signatures for apps…"
     }
   },
   "channel": {

--- a/BrightID/src/actions/apps.ts
+++ b/BrightID/src/actions/apps.ts
@@ -9,6 +9,7 @@ import {
   upsertSig,
   removeSig,
   updateSig,
+  setSigsUpdating,
   selectAllSigs,
   selectExpireableBlindSigApps,
 } from '@/reducer/appsSlice';
@@ -154,9 +155,17 @@ export const updateBlindSigs =
     return new Promise(() => {
       InteractionManager.runAfterInteractions(async () => {
         const expireableBlindSigApps = selectExpireableBlindSigApps(getState());
+        await dispatch(setSigsUpdating(true));
+        console.log('getting blind sigs started');
         for (const app of expireableBlindSigApps) {
-          await dispatch(updateBlindSig(app));
+          try {
+            await dispatch(updateBlindSig(app));
+          } catch {
+            console.log(`error in getting blind sig for ${app}`);
+          }
         }
+        await dispatch(setSigsUpdating(false));
+        console.log('getting blind sigs finished');
       });
     });
   };

--- a/BrightID/src/components/Apps/AppsScreen.tsx
+++ b/BrightID/src/components/Apps/AppsScreen.tsx
@@ -33,6 +33,7 @@ type Props = {
   setSearch: (term: string) => void;
   filteredApps: AppInfo[];
   refreshing: boolean;
+  sigsUpdating: boolean;
   refreshApps: () => void;
 };
 
@@ -49,6 +50,7 @@ export const AppsScreen = ({
   setSearch,
   filteredApps,
   refreshing,
+  sigsUpdating,
   refreshApps,
 }: Props) => {
   const headerHeight = useHeaderHeight();
@@ -115,6 +117,9 @@ export const AppsScreen = ({
       waiting = true;
     } else if (pendingLink) {
       msg = t('apps.text.pendingLink', { context: `${pendingLink.context}` });
+      waiting = true;
+    } else if (sigsUpdating) {
+      msg = t('apps.text.sigsUpdating');
       waiting = true;
     } else if (!isSponsored) {
       msg = t('apps.text.notSponsored');

--- a/BrightID/src/components/Apps/AppsScreenController.tsx
+++ b/BrightID/src/components/Apps/AppsScreenController.tsx
@@ -34,6 +34,7 @@ const AppsScreenController = () => {
   const selectLinkedSigs = useSelector(selectAllLinkedSigs);
   const pendingLink = useSelector(selectPendingLinkedContext);
   const userVerifications = useSelector((state) => state.user.verifications);
+  const sigsUpdating = useSelector((state) => state.apps.sigsUpdating);
 
   const [refreshing, setRefreshing] = useState(false);
   const [sponsoringApp, setSponsoringApp] = useState<AppInfo | undefined>(
@@ -188,6 +189,7 @@ const AppsScreenController = () => {
       filteredApps={filteredApps}
       refreshApps={refreshApps}
       refreshing={refreshing}
+      sigsUpdating={sigsUpdating}
     />
   );
 };

--- a/BrightID/src/components/Apps/model.ts
+++ b/BrightID/src/components/Apps/model.ts
@@ -319,6 +319,10 @@ export const linkAppId = async (
   const linkedTimestamp = Date.now();
   let linkSuccess = false;
   for (const sig of sigs) {
+    if (!sig.sig) {
+      // ignore invalid signatures
+      continue;
+    }
     try {
       await api.linkAppId(sig, appUserId);
       // mark sig as linked with app

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -95,29 +95,31 @@ export const HomeScreen = (props) => {
     useCallback(() => {
       retrieveImage(photoFilename).then(setProfilePhoto);
       setLoading(true);
-      if (isPrimaryDevice) {
-        dispatch(updateBlindSigs());
-      }
       dispatch(fetchUserInfo(api)).then(() => {
         setLoading(false);
       });
-      dispatch(updateSocialMediaVariations());
-      dispatch(syncAndLinkSocialMedias());
       const timeoutId = setTimeout(() => {
         setLoading(false);
       }, 3000);
       return () => {
         clearTimeout(timeoutId);
       };
-    }, [api, dispatch, isPrimaryDevice, photoFilename]),
+    }, [api, dispatch, photoFilename]),
   );
 
   useEffect(() => {
     if (api) {
       console.log(`updating apps...`);
       dispatch(fetchApps(api));
+      if (isPrimaryDevice) {
+        console.log(`updating blind sigs...`);
+        dispatch(updateBlindSigs());
+      }
+      console.log(`linking social media...`);
+      dispatch(updateSocialMediaVariations());
+      dispatch(syncAndLinkSocialMedias());
     }
-  }, [api, dispatch]);
+  }, [api, dispatch, isPrimaryDevice]);
 
   useEffect(() => {
     if (activeDevices.length) {

--- a/BrightID/src/reducer/appsSlice.ts
+++ b/BrightID/src/reducer/appsSlice.ts
@@ -21,6 +21,7 @@ const initialState: AppsState = {
   apps: [],
   linkedContexts: linkedContextsAdapter.getInitialState(),
   sigs: sigsAdapter.getInitialState(),
+  sigsUpdating: false,
 };
 
 const appsSlice = createSlice({
@@ -64,6 +65,9 @@ const appsSlice = createSlice({
     updateSig(state, action: PayloadAction<Update<SigInfo>>) {
       state.sigs = sigsAdapter.updateOne(state.sigs, action.payload);
     },
+    setSigsUpdating(state, action: PayloadAction<boolean>) {
+      state.sigsUpdating = action.payload;
+    },
   },
   extraReducers: {
     [RESET_STORE]: () => {
@@ -82,6 +86,7 @@ export const {
   removeSig,
   removeAllSigs,
   updateSig,
+  setSigsUpdating,
 } = appsSlice.actions;
 
 export const {


### PR DESCRIPTION
- Prevent multiple concurrent calls of `updateBlindSigs` by using `useEffect` instead of `useFocusEffect` to trigger its call
- Prevents single app `updateBlindSig` for a single app on linking to run simultaneously by global `updateBlindSigs`
- Updates apps info before linking to ensure recent changes to the app settings are being used
- Ignores trying to link invalid signature objects