### PR TITLE
Check secret key

### DIFF
--- a/BrightID/src/App.tsx
+++ b/BrightID/src/App.tsx
@@ -12,13 +12,14 @@ import InitialLoading from './components/Helpers/InitialLoadingScreen';
 import { NotificationBanner } from './components/Helpers/NotificationBanner';
 import MainApp from '@/routes';
 import ErrorFallback from '@/components/ErrorFallback';
+import { bootstrap } from '@/bootstrap';
+import { notificationSubscription } from '@/NotificationService';
 
 /**
  * Central part of the application
  * react-navigation is used for routing
  * read docs here: https://reactnavigation.org/
  */
-// NOTE: BOOTSTRAP happens inside of LoadingScreen
 export const App = () => {
   // setup deep linking
   const linking = {
@@ -67,13 +68,21 @@ export const App = () => {
     },
   };
 
-  console.log('RENDERING ENTIRE APP');
+  // bootstrap app when Redux-Persist is done rehydrating
+  const onBeforeLift = async () => {
+    console.log('BOOSTRAPING APP');
+    await bootstrap();
+    console.log('SUBSCRIBING TO NOTIFICATIONS');
+    notificationSubscription();
+    console.log('DONE BOOTSTRAP');
+  };
 
   return (
     <Provider store={store}>
       <PersistGate
-        loading={<InitialLoading app={true} />}
+        loading={<InitialLoading />}
         persistor={persistor}
+        onBeforeLift={onBeforeLift}
       >
         <ActionSheetProvider>
           <SafeAreaProvider>
@@ -82,7 +91,7 @@ export const App = () => {
               <NavigationContainer
                 linking={linking}
                 ref={navigationRef}
-                fallback={<InitialLoading app={false} />}
+                fallback={<InitialLoading />}
               >
                 <MainApp />
               </NavigationContainer>

--- a/BrightID/src/bootstrap.ts
+++ b/BrightID/src/bootstrap.ts
@@ -1,18 +1,9 @@
-import { Alert } from 'react-native';
-import i18next from 'i18next';
-import { dangerouslyDeleteStorage } from '@/utils/dev';
 import { store } from './store';
 import { checkTasks, syncStoreTasks } from './components/Tasks/TasksSlice';
 import { scrubOps } from '@/reducer/operationsSlice';
 import { rejoinChannels } from '@/components/PendingConnections/channelSlice';
 
-// happens inside of the loading screen
-
 export const bootstrap = async () => {
-  const {
-    user: { id },
-  } = store.getState();
-
   // update available usertasks
   store.dispatch(syncStoreTasks());
   // Initial check for completed tasks
@@ -21,18 +12,4 @@ export const bootstrap = async () => {
   store.dispatch(scrubOps());
   // restore persisted channels
   store.dispatch(rejoinChannels());
-
-  try {
-    // delete all storage if brightid is empty
-    if (id === 'empty') {
-      await dangerouslyDeleteStorage();
-      Alert.alert(
-        i18next.t('common.alert.title.lostKeys'),
-        i18next.t('common.alert.text.lostKeys'),
-      );
-      throw new Error('id is empty');
-    }
-  } catch (err) {
-    console.error(err);
-  }
 };

--- a/BrightID/src/components/Helpers/InitialLoadingScreen.tsx
+++ b/BrightID/src/components/Helpers/InitialLoadingScreen.tsx
@@ -1,23 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Spinner from 'react-native-spinkit';
-import { bootstrap } from '@/bootstrap';
-import { notificationSubscription } from '@/NotificationService';
 import { ORANGE } from '@/theme/colors';
 
-export const InitialLoadingScreen = ({ app }: { app: boolean }) => {
-  useEffect(() => {
-    return () => {
-      if (app) {
-        console.log('BOOSTRAPING APP');
-        bootstrap();
-        console.log('SUBSCRIBING TO NOTIFICATIONS');
-
-        notificationSubscription();
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+export const InitialLoadingScreen = () => {
   return (
     <View style={styles.container}>
       <Spinner

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -50,12 +50,12 @@ import {
 import { version as app_version } from '../../package.json';
 import { uInt8ArrayToB64 } from '@/utils/encoding';
 import { updateSocialMediaVariations } from '@/components/EditProfile/socialMediaThunks';
+import { discordUrl } from '@/utils/constants';
 
 /**
  * Home screen of BrightID
  * ==========================
  */
-const discordUrl = 'https://discord.gg/nTtuB2M';
 
 /** Selectors */
 

--- a/BrightID/src/components/HomeScreen.tsx
+++ b/BrightID/src/components/HomeScreen.tsx
@@ -50,7 +50,6 @@ import {
 import { version as app_version } from '../../package.json';
 import { uInt8ArrayToB64 } from '@/utils/encoding';
 import { updateSocialMediaVariations } from '@/components/EditProfile/socialMediaThunks';
-import { verifyKeypair } from '@/utils/cryptoHelper';
 
 /**
  * Home screen of BrightID
@@ -144,15 +143,6 @@ export const HomeScreen = (props) => {
   useEffect(() => {
     dispatch(setHeaderHeight(headerHeight));
   }, [dispatch, headerHeight]);
-
-  useEffect(() => {
-    console.log(`checking secret key`);
-    try {
-      verifyKeypair({ publicKey, secretKey });
-    } catch (e) {
-      Alert.alert('Invalid keypair', `${e instanceof Error ? e.message : e}`);
-    }
-  }, [secretKey, publicKey]);
 
   const { showActionSheetWithOptions } = useActionSheet();
 

--- a/BrightID/src/components/Onboarding/ImportFlow/ImportScreen.tsx
+++ b/BrightID/src/components/Onboarding/ImportFlow/ImportScreen.tsx
@@ -32,12 +32,7 @@ const ImportScreen = ({ route }) => {
         dispatch(resetRecoveryData());
         dispatch(setUserId(recoveryData.id));
       } catch (err) {
-        let errorString = '';
-        if (err instanceof Error) {
-          errorString = `${err.message}`;
-        } else {
-          errorString = `${err}`;
-        }
+        const errorString = err instanceof Error ? err.message : `${err}`;
         dispatch(
           setRecoveryError({
             errorType: RecoveryErrorType.GENERIC,

--- a/BrightID/src/components/Onboarding/ImportFlow/ImportScreen.tsx
+++ b/BrightID/src/components/Onboarding/ImportFlow/ImportScreen.tsx
@@ -10,9 +10,11 @@ import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { setRecoveryKeys } from '../RecoveryFlow/thunks/recoveryThunks';
 import {
   resetRecoveryData,
+  setRecoveryError,
   uploadCompletedByOtherSide,
 } from '../RecoveryFlow/recoveryDataSlice';
 import { clearImportChannel } from './thunks/channelThunks';
+import { RecoveryErrorType } from '@/components/Onboarding/RecoveryFlow/RecoveryError';
 
 /* Component to track import restore */
 const ImportScreen = ({ route }) => {
@@ -24,10 +26,25 @@ const ImportScreen = ({ route }) => {
   useEffect(() => {
     if (importCompleted) {
       clearImportChannel();
-      dispatch(setPrimaryDevice(!!route.params.changePrimaryDevice));
-      dispatch(setRecoveryKeys());
-      dispatch(resetRecoveryData());
-      dispatch(setUserId(recoveryData.id));
+      try {
+        dispatch(setRecoveryKeys());
+        dispatch(setPrimaryDevice(!!route.params.changePrimaryDevice));
+        dispatch(resetRecoveryData());
+        dispatch(setUserId(recoveryData.id));
+      } catch (err) {
+        let errorString = '';
+        if (err instanceof Error) {
+          errorString = `${err.message}`;
+        } else {
+          errorString = `${err}`;
+        }
+        dispatch(
+          setRecoveryError({
+            errorType: RecoveryErrorType.GENERIC,
+            errorMessage: errorString,
+          }),
+        );
+      }
     }
   }, [recoveryData, dispatch, importCompleted]);
 

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
@@ -189,9 +189,7 @@ const RecoveryCodeScreen = ({ route }) => {
         t('recovery.error.title', 'Account recovery failed'),
         message,
       );
-      if (action === 'recovery') {
-        // dispatch(clearRecoveryChannel());
-      } else if (action === 'import') {
+      if (action === 'import') {
         clearImportChannel();
       }
       dispatch(resetRecoveryData());

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RecoveryCodeScreen.tsx
@@ -80,7 +80,6 @@ const RecoveryCodeScreen = ({ route }) => {
       recoveryData.recoverStep === recover_steps.POLLING_SIGS &&
       !recoveryData.channel.pollTimerId
     ) {
-      console.log(`Start polling recovery channel...`);
       dispatch(pollRecoveryChannel());
     }
   }, [
@@ -97,6 +96,7 @@ const RecoveryCodeScreen = ({ route }) => {
       await dispatch(setupRecovery());
       // create channel and upload new publicKey to get signed by the scanner
       await dispatch(createRecoveryChannel());
+      dispatch(setRecoverStep(recover_steps.POLLING_SIGS));
     };
     const runImportEffect = async () => {
       // create publicKey, secretKey, aesKey for user
@@ -121,7 +121,6 @@ const RecoveryCodeScreen = ({ route }) => {
       if (action === 'recovery') {
         if (!id) {
           console.log(`initializing recovery process`);
-          dispatch(setRecoverStep(recover_steps.POLLING_SIGS));
           runRecoveryEffect();
         } else {
           console.log(`Not starting recovery process, user has id!`);

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
@@ -97,12 +97,7 @@ const RestoreScreen = () => {
           setRecoveryOpHash(op.hash);
         }
       } catch (err) {
-        let errorString = '';
-        if (err instanceof Error) {
-          errorString = `${err.message}`;
-        } else {
-          errorString = `${err}`;
-        }
+        const errorString = err instanceof Error ? err.message : `${err}`;
         console.log(`Error during account recovery: ${errorString}`);
         setAccountStep(AccountSteps.ERROR);
         setAccountError(errorString);
@@ -115,12 +110,7 @@ const RestoreScreen = () => {
         // restore backup can now start
         setDataStep(BackupSteps.WAITING_PASSWORD);
       } catch (err) {
-        let errorString = '';
-        if (err instanceof Error) {
-          errorString = `${err.message}`;
-        } else {
-          errorString = `${err}`;
-        }
+        const errorString = err instanceof Error ? err.message : `${err}`;
         setAccountStep(AccountSteps.ERROR);
         setAccountError(errorString);
       }

--- a/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/RestoreScreen.tsx
@@ -109,10 +109,21 @@ const RestoreScreen = () => {
       }
     };
     const finishRecovery = async () => {
-      dispatch(setRecoveryKeys());
-      setAccountStep(AccountSteps.COMPLETE);
-      // restore backup can now start
-      setDataStep(BackupSteps.WAITING_PASSWORD);
+      try {
+        dispatch(setRecoveryKeys());
+        setAccountStep(AccountSteps.COMPLETE);
+        // restore backup can now start
+        setDataStep(BackupSteps.WAITING_PASSWORD);
+      } catch (err) {
+        let errorString = '';
+        if (err instanceof Error) {
+          errorString = `${err.message}`;
+        } else {
+          errorString = `${err}`;
+        }
+        setAccountStep(AccountSteps.ERROR);
+        setAccountError(errorString);
+      }
     };
     switch (accountStep) {
       case AccountSteps.DOWNLOAD_COMPLETE:

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
@@ -29,7 +29,7 @@ const pastLimit = (timestamp) => timestamp + THREE_DAYS < Date.now();
 // THUNKS
 
 export const setupRecovery =
-  (): AppThunk => async (dispatch: AppDispatch, getState) => {
+  (): AppThunk<Promise<void>> => async (dispatch: AppDispatch, getState) => {
     console.log(`Setting up recovery...`);
     const { recoveryData } = getState();
     await createImageDirectory();
@@ -39,6 +39,15 @@ export const setupRecovery =
       const aesKey = await urlSafeRandomKey(16);
       // setup recovery data slice with new keypair
       dispatch(init({ publicKey, secretKey, aesKey }));
+    } else {
+      // we should have valid recovery data. double-check required data is available.
+      const { publicKey, secretKey } = recoveryData;
+      if (!publicKey?.length || !secretKey?.length) {
+        const { publicKey, secretKey } = await nacl.sign.keyPair();
+        const aesKey = await urlSafeRandomKey(16);
+        // setup recovery data slice with new keypair
+        dispatch(init({ publicKey, secretKey, aesKey }));
+      }
     }
   };
 

--- a/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
+++ b/BrightID/src/components/Onboarding/RecoveryFlow/thunks/recoveryThunks.ts
@@ -120,7 +120,21 @@ export const restoreUserData = async (id: string, pass: string) => {
 export const setRecoveryKeys =
   (): AppThunk => (dispatch: AppDispatch, getState) => {
     const { publicKey, secretKey } = getState().recoveryData;
-    dispatch(setKeypair({ publicKey, secretKey }));
+    let publicError = '';
+    let secretError = '';
+    if (!publicKey || publicKey.length === 0) {
+      publicError = `Publickey invalid`;
+    }
+    if (!secretKey || secretKey.length === 0) {
+      secretError = `Secretkey invalid`;
+    }
+    if (publicError || secretError) {
+      throw Error(
+        `Can not save keypair! ${publicError} - ${secretError}`,
+      );
+    } else {
+      dispatch(setKeypair({ publicKey, secretKey }));
+    }
   };
 
 export const recoverData =

--- a/BrightID/src/reducer/keypairSlice.ts
+++ b/BrightID/src/reducer/keypairSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RESET_STORE } from '@/actions/resetStore';
 
 const initialState: Keypair = {
@@ -10,7 +10,7 @@ const keypairSlice = createSlice({
   name: 'keypair',
   initialState,
   reducers: {
-    setKeypair(state, action) {
+    setKeypair(state, action: PayloadAction<Keypair>) {
       const { publicKey, secretKey } = action.payload;
       state.publicKey = publicKey;
       state.secretKey = secretKey;

--- a/BrightID/src/routes/MissingKeysScreen.tsx
+++ b/BrightID/src/routes/MissingKeysScreen.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { LIGHT_BLACK, ORANGE, WHITE, DARK_RED } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
+import ChatBox from '@/components/Icons/ChatBox';
+import { DEVICE_LARGE } from '@/utils/deviceConstants';
+import { discordUrl } from '@/utils/constants';
 
 const MissingKeysScreen = ({ keyError }: { keyError: string }) => {
   const { t } = useTranslation();
@@ -148,6 +158,32 @@ const MissingKeysScreen = ({ keyError }: { keyError: string }) => {
           </View>
         </View>
       </ScrollView>
+
+      <View style={styles.supportSection}>
+        <View style={styles.supportHeader}>
+          <Text style={styles.supportHeaderText}>Need help?</Text>
+        </View>
+        <TouchableOpacity
+          testID="JoinCommunityBtn"
+          style={styles.communityContainer}
+          onPress={() => Linking.openURL(discordUrl)}
+        >
+          <ChatBox
+            width={DEVICE_LARGE ? 22 : 20}
+            height={DEVICE_LARGE ? 22 : 20}
+            color={ORANGE}
+          />
+          <View
+            style={{
+              borderBottomWidth: 1,
+              borderBottomColor: WHITE,
+              marginLeft: 5,
+            }}
+          >
+            <Text style={styles.communityLink}>{t('home.link.community')}</Text>
+          </View>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };
@@ -245,10 +281,38 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     borderRadius: 20,
   },
+  supportSection: {
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: DEVICE_LARGE ? 17 : 15,
+  },
+  supportHeader: {
+    marginTop: 5,
+    marginBottom: 5,
+  },
+  supportHeaderText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[16],
+    textAlign: 'center',
+    color: LIGHT_BLACK,
+  },
+  communityContainer: {
+    marginTop: 5,
+    marginBottom: 5,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   resetButtonText: {
     fontFamily: 'Poppins-Medium',
     fontSize: fontSize[14],
     color: WHITE,
+  },
+  communityLink: {
+    color: ORANGE,
+    fontSize: fontSize[14],
+    fontFamily: 'Poppins-Bold',
   },
 });
 

--- a/BrightID/src/routes/MissingKeysScreen.tsx
+++ b/BrightID/src/routes/MissingKeysScreen.tsx
@@ -156,9 +156,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'column',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'center',
     margin: 10,
+    paddingLeft: 10,
+    paddingRight: 10,
   },
   header: {
     marginTop: 5,
@@ -174,13 +176,10 @@ const styles = StyleSheet.create({
   subHeaderText: {
     fontFamily: 'Poppins-Bold',
     fontSize: fontSize[14],
-    textAlign: 'center',
     color: DARK_RED,
   },
   keyErrorContainer: {
     paddingTop: 4,
-    paddingLeft: 10,
-    paddingRight: 10,
   },
   keyErrorText: {
     fontWeight: 'bold',
@@ -204,7 +203,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginLeft: 20,
   },
-  sectionItemText: { flex: 1, paddingLeft: 5 },
+  sectionItemText: {
+    flex: 1,
+    paddingLeft: 5,
+  },
   preconditionText: {
     fontFamily: 'Poppins-Bold',
     fontStyle: 'italic',
@@ -228,8 +230,6 @@ const styles = StyleSheet.create({
   resetInfoContainer: {
     marginBottom: 3,
     marginTop: 25,
-    paddingLeft: 10,
-    paddingRight: 10,
   },
   resetInfoText: {
     fontFamily: 'Poppins-Medium',

--- a/BrightID/src/routes/MissingKeysScreen.tsx
+++ b/BrightID/src/routes/MissingKeysScreen.tsx
@@ -14,8 +14,10 @@ const MissingKeysScreen = ({ keyError }: { keyError: string }) => {
           {t('missingKeysScreen.header', 'Corrupt keypair')}
         </Text>
         <Text style={styles.subHeaderText}>
-          The signing keys on this device got lost or corrupted. You can not use
-          the BrightID app unless this is fixed.
+          {t(
+            'missingKeysScreen.subHeader',
+            'The signing keys on this device got lost or corrupted. You can not use the BrightID app unless this is fixed.',
+          )}
         </Text>
       </View>
       <View style={styles.keyErrorContainer}>
@@ -25,79 +27,123 @@ const MissingKeysScreen = ({ keyError }: { keyError: string }) => {
       </View>
       <ScrollView style={styles.resetInfoContainer} persistentScrollbar={true}>
         <View>
-          <Text style={styles.optionHeaderText}>Recovery options:</Text>
+          <Text style={styles.optionHeaderText}>
+            {t('missingKeysScreen.recoveryOptions', 'Recovery options')}
+          </Text>
         </View>
         <View style={styles.section}>
-          <Text style={styles.sectionHeaderText}>Perform Social recovery</Text>
+          <Text style={styles.sectionHeaderText}>
+            {t(
+              'missingKeysScreen.options.socialRecovery',
+              'Perform Social recovery',
+            )}
+          </Text>
           <Text style={styles.preconditionText}>
-            Precondition: You have social recovery set up
+            {t(
+              'missingKeysScreen.options.socialRecovery.notes',
+              'Precondition: You have social recovery set up',
+            )}
           </Text>
 
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Uninstall and reinstall BrightID app
+              {t(
+                'missingKeysScreen.options.reinstall',
+                'Uninstall and reinstall BrightID app',
+              )}
             </Text>
           </View>
 
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Select "Recover" option at startup
+              {t(
+                'missingKeysScreen.options.socialRecovery.selectRecovery',
+                'Select "Recover" option at startup',
+              )}
             </Text>
           </View>
 
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Follow the Recovery workflow
+              {t(
+                'missingKeysScreen.options.socialRecovery.followWorkflow',
+                'Follow the Recovery workflow',
+              )}
             </Text>
           </View>
         </View>
 
         <View style={styles.section}>
           <Text style={styles.sectionHeaderText}>
-            Import from another device
+            {t(
+              'missingKeysScreen.options.import',
+              'Import from another device',
+            )}
           </Text>
           <Text style={styles.preconditionText}>
-            Precondition: You have your brightId installed on another device
+            {t(
+              'missingKeysScreen.options.import.notes',
+              'Precondition: You have your brightId installed on another device',
+            )}
           </Text>
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Uninstall and reinstall BrightID app
+              {t(
+                'missingKeysScreen.options.reinstall',
+                'Uninstall and reinstall BrightID app',
+              )}
             </Text>
           </View>
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Select "Import" option at startup
+              {t(
+                'missingKeysScreen.options.import.selectImport',
+                'Select "Import" option at startup',
+              )}
             </Text>
           </View>
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Follow the Import workflow
+              {t(
+                'missingKeysScreen.options.import.followWorkflow',
+                'Follow the Import workflow',
+              )}
             </Text>
           </View>
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionHeaderText}>Start from scratch</Text>
+          <Text style={styles.sectionHeaderText}>
+            {t('missingKeysScreen.options.restart', 'Start from scratch')}
+          </Text>
           <Text style={styles.preconditionText}>
-            This is the last-resort option. You will create a new BrightID and
-            lose all existing connections and verifications.
+            {t(
+              'missingKeysScreen.options.restart.notes',
+              'This is the last-resort option. You will create a new BrightID and lose all existing connections and verifications.',
+            )}
           </Text>
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Uninstall and reinstall BrightID app
+              {t(
+                'missingKeysScreen.options.reinstall',
+                'Uninstall and reinstall BrightID app',
+              )}
             </Text>
           </View>
           <View style={styles.sectionItem}>
             <Text>{'\u2022'}</Text>
             <Text style={styles.sectionItemText}>
-              Select "Create my BrightID" option at startup
+              {t(
+                'missingKeysScreen.options.restart.selectCreate',
+                'Select "Create my BrightID" option at startup',
+              )}
             </Text>
           </View>
         </View>

--- a/BrightID/src/routes/MissingKeysScreen.tsx
+++ b/BrightID/src/routes/MissingKeysScreen.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { LIGHT_BLACK, ORANGE, WHITE, DARK_RED } from '@/theme/colors';
+import { fontSize } from '@/theme/fonts';
+
+const MissingKeysScreen = ({ keyError }: { keyError: string }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerText}>
+          {t('missingKeysScreen.header', 'Corrupt keypair')}
+        </Text>
+        <Text style={styles.subHeaderText}>
+          The signing keys on this device got lost or corrupted. You can not use
+          the BrightID app unless this is fixed.
+        </Text>
+      </View>
+      <View style={styles.keyErrorContainer}>
+        <Text style={styles.keyErrorText}>
+          Error: <Text style={{ fontStyle: 'italic' }}>{keyError}</Text>
+        </Text>
+      </View>
+      <ScrollView style={styles.resetInfoContainer} persistentScrollbar={true}>
+        <View>
+          <Text style={styles.optionHeaderText}>Recovery options:</Text>
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionHeaderText}>Perform Social recovery</Text>
+          <Text style={styles.preconditionText}>
+            Precondition: You have social recovery set up
+          </Text>
+
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Uninstall and reinstall BrightID app
+            </Text>
+          </View>
+
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Select "Recover" option at startup
+            </Text>
+          </View>
+
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Follow the Recovery workflow
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionHeaderText}>
+            Import from another device
+          </Text>
+          <Text style={styles.preconditionText}>
+            Precondition: You have your brightId installed on another device
+          </Text>
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Uninstall and reinstall BrightID app
+            </Text>
+          </View>
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Select "Import" option at startup
+            </Text>
+          </View>
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Follow the Import workflow
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionHeaderText}>Start from scratch</Text>
+          <Text style={styles.preconditionText}>
+            This is the last-resort option. You will create a new BrightID and
+            lose all existing connections and verifications.
+          </Text>
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Uninstall and reinstall BrightID app
+            </Text>
+          </View>
+          <View style={styles.sectionItem}>
+            <Text>{'\u2022'}</Text>
+            <Text style={styles.sectionItemText}>
+              Select "Create my BrightID" option at startup
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 10,
+  },
+  header: {
+    marginTop: 5,
+    marginBottom: 5,
+  },
+  headerText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[20],
+    textAlign: 'center',
+    color: LIGHT_BLACK,
+    marginBottom: 10,
+  },
+  subHeaderText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[14],
+    textAlign: 'center',
+    color: DARK_RED,
+  },
+  keyErrorContainer: {
+    paddingTop: 4,
+    paddingLeft: 10,
+    paddingRight: 10,
+  },
+  keyErrorText: {
+    fontWeight: 'bold',
+  },
+  section: {
+    marginTop: 10,
+    marginBottom: 15,
+  },
+  optionHeaderText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[18],
+    textAlign: 'center',
+    color: LIGHT_BLACK,
+  },
+  sectionHeaderText: {
+    fontFamily: 'Poppins-Bold',
+    fontSize: fontSize[16],
+    color: LIGHT_BLACK,
+  },
+  sectionItem: {
+    flexDirection: 'row',
+    marginLeft: 20,
+  },
+  sectionItemText: { flex: 1, paddingLeft: 5 },
+  preconditionText: {
+    fontFamily: 'Poppins-Bold',
+    fontStyle: 'italic',
+    fontSize: fontSize[14],
+    marginBottom: 4,
+  },
+  switchNodeButton: {
+    width: '90%',
+    paddingTop: 8,
+    paddingBottom: 8,
+    backgroundColor: ORANGE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 20,
+  },
+  switchNodeButtonText: {
+    fontFamily: 'Poppins-Medium',
+    fontSize: fontSize[15],
+    color: WHITE,
+  },
+  resetInfoContainer: {
+    marginBottom: 3,
+    marginTop: 25,
+    paddingLeft: 10,
+    paddingRight: 10,
+  },
+  resetInfoText: {
+    fontFamily: 'Poppins-Medium',
+    fontSize: fontSize[14],
+    color: LIGHT_BLACK,
+  },
+  resetButton: {
+    width: '70%',
+    paddingTop: 8,
+    paddingBottom: 8,
+    backgroundColor: ORANGE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 20,
+  },
+  resetButtonText: {
+    fontFamily: 'Poppins-Medium',
+    fontSize: fontSize[14],
+    color: WHITE,
+  },
+});
+
+export default MissingKeysScreen;

--- a/BrightID/src/utils/constants.ts
+++ b/BrightID/src/utils/constants.ts
@@ -158,3 +158,5 @@ export enum BrightIdNetwork {
   TEST = 'test',
   NODE = 'node',
 }
+
+export const discordUrl = 'https://discord.gg/nTtuB2M';

--- a/BrightID/src/utils/cryptoHelper.test.ts
+++ b/BrightID/src/utils/cryptoHelper.test.ts
@@ -1,0 +1,101 @@
+import nacl from 'tweetnacl';
+import { verifyKeypair } from '@/utils/cryptoHelper';
+import { uInt8ArrayToB64 } from '@/utils/encoding';
+
+describe('verify keypair', () => {
+  const validKeypair: Keypair = {
+    publicKey: undefined,
+    secretKey: undefined,
+  };
+
+  beforeAll(async () => {
+    // prepare valid keypair, publicKey should be Base64-encoded
+    const keypair = await nacl.sign.keyPair();
+    validKeypair.publicKey = uInt8ArrayToB64(keypair.publicKey);
+    validKeypair.secretKey = keypair.secretKey;
+  });
+
+  it('should fail with undefined publicKey', () => {
+    const publicKey = undefined;
+    const { secretKey } = validKeypair;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/publicKey undefined/);
+  });
+
+  it('should fail with non-base64 publicKey', () => {
+    const publicKey = '123';
+    const { secretKey } = validKeypair;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/publicKey is not base64-encoded/);
+  });
+
+  it('should fail with undefined secretKey', () => {
+    const { publicKey } = validKeypair;
+    const secretKey = undefined;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/secretKey undefined/);
+  });
+
+  it('should fail with undefined keypair', () => {
+    const publicKey = undefined;
+    const secretKey = undefined;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/undefined/);
+  });
+
+  it('should fail with short secretKey', () => {
+    const { publicKey } = validKeypair;
+    const secretKey = new Uint8Array(nacl.sign.secretKeyLength - 1);
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/secretKey size wrong/);
+  });
+
+  it('should fail with long secretKey', () => {
+    const { publicKey } = validKeypair;
+    const secretKey = new Uint8Array(nacl.sign.secretKeyLength + 1);
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/secretKey size wrong/);
+  });
+
+  it('should fail with short publicKey', () => {
+    const { secretKey } = validKeypair;
+    const publicKey = uInt8ArrayToB64(
+      new Uint8Array(nacl.sign.publicKeyLength - 1),
+    );
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/publicKey size wrong/);
+  });
+
+  it('should fail with long publicKey', () => {
+    const { secretKey } = validKeypair;
+    const publicKey = uInt8ArrayToB64(
+      new Uint8Array(nacl.sign.publicKeyLength + 1),
+    );
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/publicKey size wrong/);
+  });
+
+  it('should fail with valid but mismatched secret/public key', async () => {
+    const otherKeypair = await nacl.sign.keyPair();
+    const { publicKey } = validKeypair;
+    const { secretKey } = otherKeypair;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).toThrowError(/publicKey does not match secretKey/);
+  });
+
+  it('should succeed with valid keypair', () => {
+    const { publicKey, secretKey } = validKeypair;
+    expect(() => {
+      verifyKeypair({ publicKey, secretKey });
+    }).not.toThrowError();
+  });
+});

--- a/BrightID/src/utils/cryptoHelper.ts
+++ b/BrightID/src/utils/cryptoHelper.ts
@@ -24,9 +24,6 @@ export const verifyKeypair = ({
   publicKey: string;
   secretKey: Uint8Array;
 }) => {
-  const publicError = '';
-  const secretError = '';
-
   // check public key
   if (!publicKey) {
     throw Error('Invalid keypair: publicKey undefined');
@@ -54,12 +51,6 @@ export const verifyKeypair = ({
   if (secretKey.length !== nacl.sign.secretKeyLength) {
     throw Error(
       `secretKey size wrong, expected: ${nacl.sign.secretKeyLength} - actual: ${secretKey.length}`,
-    );
-  }
-
-  if (publicError || secretError) {
-    throw Error(
-      `Invalid keypair: ${publicError && `${publicError} -`} ${secretError}`,
     );
   }
 

--- a/BrightID/src/utils/cryptoHelper.ts
+++ b/BrightID/src/utils/cryptoHelper.ts
@@ -1,4 +1,6 @@
 import CryptoJS from 'crypto-js';
+import nacl from 'tweetnacl';
+import { b64ToUint8Array, UInt8ArrayEqual } from '@/utils/encoding';
 
 export const encryptData = (dataObj: any, aesKey: string) => {
   const dataStr = JSON.stringify(dataObj);
@@ -14,3 +16,56 @@ export const decryptData = (data: string, aesKey: string) => {
 
 export const hashSocialProfile = (data: string) =>
   CryptoJS.MD5(data).toString();
+
+export const verifyKeypair = ({
+  publicKey,
+  secretKey,
+}: {
+  publicKey: string;
+  secretKey: Uint8Array;
+}) => {
+  const publicError = '';
+  const secretError = '';
+
+  // check public key
+  if (!publicKey) {
+    throw Error('Invalid keypair: publicKey undefined');
+  }
+  if (publicKey.length === 0) {
+    throw Error(`Invalid keypair: publicKey empty`);
+  }
+  // publicKey is expected to be base64-encoded UInt8Array. Try to decode it.
+  let pubKeyUInt8: Uint8Array;
+  try {
+    pubKeyUInt8 = b64ToUint8Array(publicKey);
+  } catch {
+    throw Error(`publicKey is not base64-encoded`);
+  }
+  if (pubKeyUInt8.length !== nacl.sign.publicKeyLength) {
+    throw Error(
+      `publicKey size wrong, expected: ${nacl.sign.publicKeyLength} - Actual: ${pubKeyUInt8.length}`,
+    );
+  }
+
+  // check secret key
+  if (!secretKey) {
+    throw Error(`Invalid keypair: secretKey undefined`);
+  }
+  if (secretKey.length !== nacl.sign.secretKeyLength) {
+    throw Error(
+      `secretKey size wrong, expected: ${nacl.sign.secretKeyLength} - actual: ${secretKey.length}`,
+    );
+  }
+
+  if (publicError || secretError) {
+    throw Error(
+      `Invalid keypair: ${publicError && `${publicError} -`} ${secretError}`,
+    );
+  }
+
+  // check if public key matches secret key
+  const { publicKey: newPub } = nacl.sign.keyPair.fromSecretKey(secretKey);
+  if (!UInt8ArrayEqual(newPub, pubKeyUInt8)) {
+    throw Error(`publicKey does not match secretKey`);
+  }
+};

--- a/BrightID/src/utils/encoding.ts
+++ b/BrightID/src/utils/encoding.ts
@@ -5,8 +5,9 @@ import CryptoJS from 'crypto-js';
 import { compose } from 'ramda';
 
 export const UInt8ArrayEqual = (first: Uint8Array, second: Uint8Array) => {
+  // first compare bytelength
   if (first.byteLength !== second.byteLength) return false;
-  // bytelength matches, now check in detail
+  // bytelength matches, now compare each array element
   return first.every((value, index) => value === second[index]);
 };
 

--- a/BrightID/src/utils/encoding.ts
+++ b/BrightID/src/utils/encoding.ts
@@ -4,6 +4,12 @@ import { Buffer } from 'buffer';
 import CryptoJS from 'crypto-js';
 import { compose } from 'ramda';
 
+export const UInt8ArrayEqual = (first: Uint8Array, second: Uint8Array) => {
+  if (first.byteLength !== second.byteLength) return false;
+  // bytelength matches, now check in detail
+  return first.every((value, index) => value === second[index]);
+};
+
 /**
  *
  * @param {Uint8Array} array
@@ -99,7 +105,7 @@ export const randomKey = (size: number) =>
     });
   });
 
-export const urlSafeRandomKey = async (size: number = 9) => {
+export const urlSafeRandomKey = async (size = 9) => {
   const key = await randomKey(size);
   return b64ToUrlSafeB64(key);
 };


### PR DESCRIPTION
Implement various changes to prevent invalid/missing secret key issues:
- At app startup check for valid keypair. If the keypair is invalid, show according screen and prevent any usage of app
- When performing recovery, check if a valid keypair is set. If the keypair is not valid, show an error and abort the recovery process
- When importing BrightID from another device, check if a valid keypair is set. If the keypair is not valid, show an error and abort the import process
- Fix potential race condition in app startup process