### PR TITLE
feat: add ADD_SUPER_USER_APP import type

### DIFF
--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -314,6 +314,7 @@
       "bothPrimary": "Both devices configured as primary devices. You can only have a single primary device. Configure one of the devices as secondary to be able to sync them.",
       "confirmAdd": "Are you sure that you want to export your BrightID into another device?",
       "confirmAddPrimary": "Are you sure that you want to export your BrightID into another device and set that as your primary device?",
+      "addSuperUserApp": "Are you sure that you want to add {{name}} as a super user app? Do this only if you highly trust {{name}} application because they can control your BrightID.",
       "confirmRemove": "Are you sure that you want to remove your BrightID from \"{{name}}\"?",
       "confirmSync": "Share and sync your BrightID data with this device?",
       "noPrimary": "Your devices can only be synced by the primary device."

--- a/BrightID/src/components/Onboarding/ImportFlow/AddDeviceScreen.tsx
+++ b/BrightID/src/components/Onboarding/ImportFlow/AddDeviceScreen.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
+  Alert,
   StatusBar,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
-  Alert,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
 import { fontSize } from '@/theme/fonts';
-import { WHITE, BLACK, DARKER_GREY, ORANGE } from '@/theme/colors';
+import { BLACK, DARKER_GREY, ORANGE, WHITE } from '@/theme/colors';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import {
   addDevice,
@@ -70,7 +70,16 @@ const AddDeviceScreen = ({ route }) => {
   const [uploadDataError, setUploadDataError] = useState('');
 
   const isPrimary = useSelector(selectIsPrimaryDevice);
-  const changePrimaryDevice = isPrimary && route.params.changePrimaryDevice;
+  const isSuperUserApp = route.params.isSuperUserApp === true;
+  const changePrimaryDevice =
+    !isSuperUserApp && isPrimary && route.params.changePrimaryDevice;
+  const name = route.params.name || 'Unknown App';
+
+  useEffect(() => {
+    if (name) {
+      setDeviceName(name);
+    }
+  }, [name]);
 
   const handleSubmit = async () => {
     try {
@@ -96,7 +105,7 @@ const AddDeviceScreen = ({ route }) => {
       console.log(`Starting upload of local info`);
       try {
         setUploadDataStep(UploadDataSteps.UPLOADING);
-        await dispatch(uploadAllInfoAfter(0));
+        await dispatch(uploadAllInfoAfter(0, true));
         setUploadDataStep(UploadDataSteps.COMPLETE);
         if (isPrimary) {
           dispatch(setPrimaryDevice(!changePrimaryDevice));
@@ -182,7 +191,9 @@ const AddDeviceScreen = ({ route }) => {
     const showConfirmDialog = () => {
       return Alert.alert(
         t('common.alert.title.pleaseConfirm'),
-        changePrimaryDevice
+        isSuperUserApp
+          ? t('devices.alert.addSuperUserApp', { name })
+          : changePrimaryDevice
           ? t('devices.alert.confirmAddPrimary')
           : t('devices.alert.confirmAdd'),
         [

--- a/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
+++ b/BrightID/src/components/PendingConnections/ScanCodeScreen.tsx
@@ -133,6 +133,7 @@ export const ScanCodeScreen = () => {
           if (urlType) channelURL.searchParams.delete('t');
 
           switch (urlType) {
+            case qrCodeURL_types.ADD_SUPER_USER_APP:
             case qrCodeURL_types.RECOVERY:
             case qrCodeURL_types.SYNC:
             case qrCodeURL_types.IMPORT: {
@@ -143,6 +144,10 @@ export const ScanCodeScreen = () => {
               const changePrimaryDevice =
                 channelURL.searchParams.get('p') === 'true';
               channelURL.searchParams.delete('p');
+
+              const name = channelURL.searchParams.get('n');
+              console.log(channelURL.href);
+              channelURL.searchParams.delete('n');
 
               const channelId = hash(aesKey);
               console.log(
@@ -163,9 +168,15 @@ export const ScanCodeScreen = () => {
                   syncing: true,
                   asScanner: true,
                 });
-              } else if (urlType === qrCodeURL_types.IMPORT) {
+              } else if (
+                urlType === qrCodeURL_types.IMPORT ||
+                urlType === qrCodeURL_types.ADD_SUPER_USER_APP
+              ) {
                 navigation.navigate('Add Device', {
                   changePrimaryDevice,
+                  name,
+                  isSuperUserApp:
+                    urlType === qrCodeURL_types.ADD_SUPER_USER_APP,
                 });
               }
               break;

--- a/BrightID/src/utils/constants.ts
+++ b/BrightID/src/utils/constants.ts
@@ -114,6 +114,7 @@ export enum qrCodeURL_types {
   RECOVERY = '2', // qrcode url is for recovery channel
   IMPORT = '3', // qrcode url is for import channel
   SYNC = '4', // qrcode url is for syncing devices channel
+  ADD_SUPER_USER_APP = '5', // qrcode url is for adding super user app
 }
 
 export enum report_sources {


### PR DESCRIPTION
We're adding this to be able to login to Aura with the import feature from BrightID.
Current import functionality imports every data, including connections which we don't need in Aura. So I added an import type to work for this purpose and only import basic user info

You can use this frontend to test the feature:
https://aura-frontend-git-brightid-superapp-import-brightid.vercel.app/