### PR TITLE
refactor: handle unknown connection levels

### DIFF
--- a/BrightID/e2e/connectionDetails.spec.ts
+++ b/BrightID/e2e/connectionDetails.spec.ts
@@ -11,7 +11,7 @@ import {
   navigateHome,
   operationTimeout,
 } from './testUtils';
-import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { getConnectionLevelString } from '@/utils/connectionLevelStrings';
 import { connection_levels } from '@/utils/constants';
 
 describe('Connection details', () => {
@@ -128,7 +128,7 @@ describe('Connection details', () => {
     });
     test('should show correct connection level', async () => {
       await expect(element(by.id('ConnectionLevelText'))).toHaveText(
-        connectionLevelStrings[connection_levels.ALREADY_KNOWN],
+        getConnectionLevelString(connection_levels.ALREADY_KNOWN),
       );
     });
     test('should show correct mutual connections count', async () => {
@@ -209,14 +209,14 @@ describe('Connection details', () => {
       await expect(element(by.id('ConnectionLevelSliderPopup'))).toBeVisible();
       // check initial value
       await expect(sliderText).toHaveText(
-        connectionLevelStrings[connection_levels.ALREADY_KNOWN],
+        getConnectionLevelString(connection_levels.ALREADY_KNOWN),
       );
       // set new value by swiping right
       // "adjustSliderToPosition" is only available on iOS, so we have to use the not-so-exact "swipe" method
       // This will swipe all the way to the right, so the new expected level is RECOVERY
       await slider.swipe('right', 'fast');
       await expect(sliderText).toHaveText(
-        connectionLevelStrings[connection_levels.RECOVERY],
+        getConnectionLevelString(connection_levels.RECOVERY),
       );
 
       // click save button
@@ -227,13 +227,13 @@ describe('Connection details', () => {
       ).not.toBeVisible();
       // verify new value is displayed
       await expect(element(by.id('ConnectionLevelText'))).toHaveText(
-        connectionLevelStrings[connection_levels.RECOVERY],
+        getConnectionLevelString(connection_levels.RECOVERY),
       );
       // wait until operation is confirmed in the backend
       await new Promise((r) => setTimeout(r, operationTimeout));
       // verify new value is still displayed after operation confirmed
       await expect(element(by.id('ConnectionLevelText'))).toHaveText(
-        connectionLevelStrings[connection_levels.RECOVERY],
+        getConnectionLevelString(connection_levels.RECOVERY),
       );
     });
 

--- a/BrightID/e2e/reconnect.spec.ts
+++ b/BrightID/e2e/reconnect.spec.ts
@@ -1,5 +1,5 @@
 import { by, element, expect } from 'detox';
-import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { getConnectionLevelString } from '@/utils/connectionLevelStrings';
 import {
   createBrightID,
   createFakeConnection,
@@ -60,14 +60,14 @@ describe('Reconnect existing connection', () => {
     xit('should reconnect with different connection level', async () => {
       // check initial value
       await expect(element(by.id('ConnectionLevelSliderText'))).toHaveText(
-        connectionLevelStrings[connection_levels.JUST_MET],
+        getConnectionLevelString(connection_levels.JUST_MET),
       );
       // set new value by swiping right
       // "adjustSliderToPosition" is only available on iOS, so we have to use the not-so-exact "swipe" method
       // This will swipe all the way to the right, so the new expected level is RECOVERY
       await element(by.id('ReconnectSliderView')).swipe('right', 'fast');
       await expect(element(by.id('ConnectionLevelSliderText'))).toHaveText(
-        connectionLevelStrings[connection_levels.RECOVERY],
+        getConnectionLevelString(connection_levels.RECOVERY),
       );
       await element(by.id('updateBtn')).tap();
       // should move to connections screen
@@ -78,7 +78,7 @@ describe('Reconnect existing connection', () => {
         .withTimeout(operationTimeout);
       // new connection level should be set
       await expect(element(by.id('connection_level-0'))).toHaveText(
-        connectionLevelStrings[connection_levels.RECOVERY],
+        getConnectionLevelString(connection_levels.RECOVERY),
       );
     });
 

--- a/BrightID/e2e/testUtils.ts
+++ b/BrightID/e2e/testUtils.ts
@@ -2,7 +2,7 @@ import './i18n_for_tests';
 import i18next from 'i18next';
 import { by, element, expect } from 'detox';
 import { connection_levels } from '@/utils/constants';
-import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { getConnectionLevelString } from '@/utils/connectionLevelStrings';
 import { b64ToUint8Array } from '@/utils/encoding';
 
 const testUserName = 'Vincent Vega';
@@ -311,7 +311,9 @@ const interConnect = async (
 
   // open connection test ActionSheet
   const actionSheetTitle = 'Connection Test options';
-  const actionTitle = `Connect with all other fake connections - ${connectionLevelStrings[connectionLevel]}`;
+  const actionTitle = `Connect with all other fake connections - ${getConnectionLevelString(
+    connectionLevel,
+  )}`;
 
   await element(by.id('connectionTestBtn')).tap();
   // ActionSheet does not support testID, so match based on text.

--- a/BrightID/locales/en/translation.json
+++ b/BrightID/locales/en/translation.json
@@ -612,6 +612,7 @@
   "pendingConnections": {
     "label": {
       "alreadyKnown": "Already known",
+      "unknownLevel": "Unknown Level",
       "connections": "Connections",
       "created": "Joined BrightID {{date}}",
       "groups": "Groups",

--- a/BrightID/src/actions/fakeContact.ts
+++ b/BrightID/src/actions/fakeContact.ts
@@ -3,15 +3,15 @@ import RNFetchBlob from 'rn-fetch-blob';
 import { Alert } from 'react-native';
 import { createSelector } from '@reduxjs/toolkit';
 import {
-  uInt8ArrayToB64,
   b64ToUrlSafeB64,
+  uInt8ArrayToB64,
   urlSafeRandomKey,
 } from '@/utils/encoding';
 import { encryptData } from '@/utils/cryptoHelper';
 import { selectChannelById } from '@/components/PendingConnections/channelSlice';
 import {
-  selectConnectionById,
   selectAllConnections,
+  selectConnectionById,
 } from '@/reducer/connectionsSlice';
 import { names } from '@/utils/fakeNames';
 import { connectFakeUsers } from '@/utils/fakeHelper';
@@ -19,7 +19,7 @@ import { retrieveImage } from '@/utils/filesystem';
 import { PROFILE_VERSION } from '@/utils/constants';
 import { addOperation } from '@/reducer/operationsSlice';
 import { NodeApi } from '@/api/brightId';
-import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { getConnectionLevelString } from '@/utils/connectionLevelStrings';
 
 /** SELECTORS */
 
@@ -107,7 +107,9 @@ export const connectWithOtherFakeConnections =
     const otherFakeUsers = selectOtherFakeConnections(getState(), id);
 
     console.log(
-      `Connecting ${id} with ${otherFakeUsers.length} fake connections as ${connectionLevelStrings[level]}`,
+      `Connecting ${id} with ${
+        otherFakeUsers.length
+      } fake connections as ${getConnectionLevelString(level)}`,
     );
     for (const otherUser of otherFakeUsers) {
       const ops = await connectFakeUsers(

--- a/BrightID/src/components/Connections/TrustLevelView.tsx
+++ b/BrightID/src/components/Connections/TrustLevelView.tsx
@@ -4,11 +4,11 @@ import Material from 'react-native-vector-icons/MaterialIcons';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
 import {
-  connectionLevelColors,
-  connectionLevelStrings,
+  getConnectionLevelColor,
+  getConnectionLevelString,
 } from '@/utils/connectionLevelStrings';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
-import { BLUE, BLACK } from '@/theme/colors';
+import { BLACK, BLUE } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import { connection_levels } from '@/utils/constants';
 
@@ -38,10 +38,10 @@ function TrustLevelView({ level, connectionId }: Props) {
           testID="ConnectionLevelText"
           style={[
             styles.trustLevelText,
-            { color: connectionLevelColors[level] },
+            { color: getConnectionLevelColor(level) },
           ]}
         >
-          {connectionLevelStrings[level]}
+          {getConnectionLevelString(level)}
         </Text>
       </View>
       {level !== connection_levels.REPORTED && (

--- a/BrightID/src/components/Connections/TrustlevelSlider.tsx
+++ b/BrightID/src/components/Connections/TrustlevelSlider.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { useTranslation } from 'react-i18next';
 import { connection_levels } from '@/utils/constants';
-import { WIDTH, DEVICE_LARGE } from '@/utils/deviceConstants';
-import { ORANGE, BLACK } from '@/theme/colors';
+import { DEVICE_LARGE, WIDTH } from '@/utils/deviceConstants';
+import { BLACK, ORANGE } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import {
-  connectionLevelColors,
-  connectionLevelStrings,
+  getConnectionLevelColor,
+  getConnectionLevelString,
 } from '@/utils/connectionLevelStrings';
 
 type TrustlevelSliderProps = {
@@ -83,10 +83,10 @@ const TrustlevelSlider = ({
           testID="ConnectionLevelSliderText"
           style={[
             styles.labelText,
-            { color: connectionLevelColors[currentLevel] },
+            { color: getConnectionLevelColor(currentLevel) },
           ]}
         >
-          {connectionLevelStrings[currentLevel]}
+          {getConnectionLevelString(currentLevel)}
         </Text>
       </View>
       {verbose && (
@@ -103,12 +103,12 @@ const TrustlevelSlider = ({
         minimumValue={minValue}
         maximumValue={maxValue}
         step={1}
-        minimumTrackTintColor={
-          connectionLevelColors[connection_levels.RECOVERY]
-        }
-        maximumTrackTintColor={
-          connectionLevelColors[connection_levels.REPORTED]
-        }
+        minimumTrackTintColor={getConnectionLevelColor(
+          connection_levels.RECOVERY,
+        )}
+        maximumTrackTintColor={getConnectionLevelColor(
+          connection_levels.REPORTED,
+        )}
         thumbTintColor={ORANGE}
         onValueChange={valueChangeHandler}
       />

--- a/BrightID/src/components/Helpers/ConnectionStatus.tsx
+++ b/BrightID/src/components/Helpers/ConnectionStatus.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import moment from 'moment';
 import {
-  connectionLevelColors,
-  connectionLevelStrings,
+  getConnectionLevelColor,
+  getConnectionLevelString,
 } from '@/utils/connectionLevelStrings';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { GREY, RED } from '@/theme/colors';
@@ -87,10 +87,10 @@ export const ConnectionStatus = ({
           testID={`connection_level-${index}`}
           style={[
             styles.connectionLevel,
-            { color: connectionLevelColors[level] },
+            { color: getConnectionLevelColor(level) },
           ]}
         >
-          {connectionLevelStrings[level]}
+          {getConnectionLevelString(level)}
         </Text>
         {ConnectionDate}
         {InfoText}

--- a/BrightID/src/components/PendingConnections/RatingView.tsx
+++ b/BrightID/src/components/PendingConnections/RatingView.tsx
@@ -6,8 +6,8 @@ import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import { DARKER_GREY } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import {
-  connectionLevelColors,
-  connectionLevelStrings,
+  getConnectionLevelColor,
+  getConnectionLevelString,
 } from '@/utils/connectionLevelStrings';
 import { RatingButton } from './RatingButton';
 
@@ -28,20 +28,20 @@ export const RatingView = ({
       </Text>
       <View style={styles.buttonsContainer}>
         <RatingButton
-          color={connectionLevelColors[connection_levels.SUSPICIOUS]}
-          label={connectionLevelStrings[connection_levels.SUSPICIOUS]}
+          color={getConnectionLevelColor(connection_levels.SUSPICIOUS)}
+          label={getConnectionLevelString(connection_levels.SUSPICIOUS)}
           handleClick={() => abuseHandler()}
           testID={`${connection_levels.SUSPICIOUS}Btn`}
         />
         <RatingButton
-          color={connectionLevelColors[connection_levels.JUST_MET]}
-          label={connectionLevelStrings[connection_levels.JUST_MET]}
+          color={getConnectionLevelColor(connection_levels.JUST_MET)}
+          label={getConnectionLevelString(connection_levels.JUST_MET)}
           handleClick={() => setLevelHandler(connection_levels.JUST_MET)}
           testID={`${connection_levels.JUST_MET}Btn`}
         />
         <RatingButton
-          color={connectionLevelColors[connection_levels.ALREADY_KNOWN]}
-          label={connectionLevelStrings[connection_levels.ALREADY_KNOWN]}
+          color={getConnectionLevelColor(connection_levels.ALREADY_KNOWN)}
+          label={getConnectionLevelString(connection_levels.ALREADY_KNOWN)}
           handleClick={() => setLevelHandler(connection_levels.ALREADY_KNOWN)}
           testID={`${connection_levels.ALREADY_KNOWN}Btn`}
         />

--- a/BrightID/src/utils/connectionLevelStrings.ts
+++ b/BrightID/src/utils/connectionLevelStrings.ts
@@ -1,8 +1,10 @@
 import i18next from 'i18next';
-import { YELLOW, RED, DARK_GREEN } from '@/theme/colors';
+import { DARK_GREEN, GREY, RED, YELLOW } from '@/theme/colors';
 import { connection_levels } from './constants';
 
-export const connectionLevelStrings = {
+const connectionLevelStrings: {
+  [key in ValueOf<typeof connection_levels>]: string;
+} = {
   [connection_levels.REPORTED]: `✋ ${i18next.t(
     'pendingConnections.label.reported',
   )}`,
@@ -20,10 +22,23 @@ export const connectionLevelStrings = {
   )}`,
 };
 
-export const connectionLevelColors = {
+export function getConnectionLevelString(connectionLevel: string): string {
+  return (
+    connectionLevelStrings[connectionLevel] ??
+    i18next.t('pendingConnections.label.unknownLevel')
+  );
+}
+
+const connectionLevelColors: {
+  [key in ValueOf<typeof connection_levels>]: string;
+} = {
   [connection_levels.REPORTED]: RED,
   [connection_levels.SUSPICIOUS]: RED,
   [connection_levels.JUST_MET]: YELLOW,
   [connection_levels.ALREADY_KNOWN]: DARK_GREEN,
   [connection_levels.RECOVERY]: DARK_GREEN,
 };
+
+export function getConnectionLevelColor(connectionLevel: string): string {
+  return connectionLevelColors[connectionLevel] ?? GREY;
+}

--- a/BrightID/src/utils/connectionTestButton.tsx
+++ b/BrightID/src/utils/connectionTestButton.tsx
@@ -11,7 +11,7 @@ import {
   reconnectFakeConnection,
 } from '../actions/fakeContact';
 import { connection_levels } from '@/utils/constants';
-import { connectionLevelStrings } from '@/utils/connectionLevelStrings';
+import { getConnectionLevelString } from '@/utils/connectionLevelStrings';
 
 /*
 Return a button that opens actionsheet with test methods
@@ -20,15 +20,15 @@ const btnOptions = [
   'Accept all group invites',
   'Reconnect with changed profile',
   'Reconnect with identical profile',
-  `Connect with all other fake connections - ${
-    connectionLevelStrings[connection_levels.JUST_MET]
-  }`,
-  `Connect with all other fake connections - ${
-    connectionLevelStrings[connection_levels.ALREADY_KNOWN]
-  }`,
-  `Connect with all other fake connections - ${
-    connectionLevelStrings[connection_levels.RECOVERY]
-  }`,
+  `Connect with all other fake connections - ${getConnectionLevelString(
+    connection_levels.JUST_MET,
+  )}`,
+  `Connect with all other fake connections - ${getConnectionLevelString(
+    connection_levels.ALREADY_KNOWN,
+  )}`,
+  `Connect with all other fake connections - ${getConnectionLevelString(
+    connection_levels.RECOVERY,
+  )}`,
   'cancel',
 ];
 


### PR DESCRIPTION
We might need to define some custom levels for when an Aura player is evaluating a BrightID user which is not necessarily a BrightID connection of that Aura player.
This pull request is to make sure that the UI does not break with these unknown connection levels.