### PR TITLE
feat: pull connection backup data before uploading

### DIFF
--- a/BrightID/src/components/Connections/ConnectionCard.tsx
+++ b/BrightID/src/components/Connections/ConnectionCard.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Image,
@@ -25,18 +19,18 @@ import i18next from 'i18next';
 import { useDispatch, useSelector } from '@/store/hooks';
 import { connection_levels, CONNECTION_STALE_AGE } from '@/utils/constants';
 import { photoDirectory } from '@/utils/filesystem';
-import { staleConnection, deleteConnection, addOperation } from '@/actions';
+import { addOperation, deleteConnection, staleConnection } from '@/actions';
 import { DEVICE_LARGE, WIDTH } from '@/utils/deviceConstants';
 import {
-  WHITE,
-  LIGHT_ORANGE,
-  LIGHT_BLACK,
   DARK_ORANGE,
+  LIGHT_BLACK,
+  LIGHT_ORANGE,
   RED,
+  WHITE,
 } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import { ConnectionStatus } from '@/components/Helpers/ConnectionStatus';
-import { backupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
+import { syncAndBackupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import { encryptAesKey } from '@/utils/invites';
 import { useNodeApiContext } from '@/context/NodeApiContext';
 
@@ -163,7 +157,7 @@ const ConnectionCard = (props: Props) => {
               if (index === 0) {
                 dispatch(deleteConnection(id));
                 if (backupCompleted) {
-                  await dispatch(backupUser());
+                  await dispatch(syncAndBackupUser());
                 }
               }
             },

--- a/BrightID/src/components/Connections/models/reportConnection.ts
+++ b/BrightID/src/components/Connections/models/reportConnection.ts
@@ -1,5 +1,5 @@
 import { addOperation, reportAndHideConnection } from '@/actions';
-import { backupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
+import { syncAndBackupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import { connection_levels } from '@/utils/constants';
 import { NodeApi } from '@/api/brightId';
 
@@ -23,7 +23,7 @@ export const reportConnection =
       // remove connection from local storage
       dispatch(reportAndHideConnection({ id, reason }));
       if (backupCompleted) {
-        await dispatch(backupUser());
+        await dispatch(syncAndBackupUser());
       }
     } catch (err) {
       err instanceof Error ? console.warn(err.message) : console.log(err);

--- a/BrightID/src/components/Groups/actions.ts
+++ b/BrightID/src/components/Groups/actions.ts
@@ -10,7 +10,7 @@ import { selectConnectionById } from '@/reducer/connectionsSlice';
 import { addOperation } from '@/reducer/operationsSlice';
 import {
   backupPhoto,
-  backupUser,
+  syncAndBackupUser,
 } from '../Onboarding/RecoveryFlow/thunks/backupThunks';
 import { NodeApi } from '@/api/brightId';
 import { group_states } from '@/utils/constants';
@@ -90,7 +90,7 @@ export const createNewGroup =
       }
 
       if (backupCompleted) {
-        await dispatch(backupUser());
+        await dispatch(syncAndBackupUser());
         if (filename) {
           await dispatch(backupPhoto(groupId, filename));
         }

--- a/BrightID/src/components/Notifications/InviteCard.tsx
+++ b/BrightID/src/components/Notifications/InviteCard.tsx
@@ -1,31 +1,30 @@
 import * as React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, Alert } from 'react-native';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
-import { useContext } from 'react';
 import { useDispatch, useSelector } from '@/store/hooks';
 import { DEVICE_LARGE } from '@/utils/deviceConstants';
 import {
   DARK_ORANGE,
-  GREEN,
   DARKER_GREY,
+  GREEN,
   LIGHT_GREY,
   WHITE,
 } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import {
   acceptInvite,
-  rejectInvite,
-  joinGroup,
-  selectConnectionById,
   addOperation,
+  joinGroup,
+  rejectInvite,
+  selectConnectionById,
   selectGroupName,
 } from '@/actions';
 import { GroupPhoto } from '@/components/Groups/GroupPhoto';
 import {
-  backupUser,
   backupPhoto,
+  syncAndBackupUser,
 } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import Check from '@/components/Icons/Check';
 import xGrey from '@/static/x_grey.svg';
@@ -88,7 +87,7 @@ const InviteCard = (props) => {
         }),
       );
       if (backupCompleted) {
-        await dispatch(backupUser());
+        await dispatch(syncAndBackupUser());
         if (invite.groupObj.photo && invite.groupObj.photo.filename) {
           await dispatch(
             backupPhoto(invite.groupObj.id, invite.groupObj.photo.filename),

--- a/BrightID/src/components/PendingConnections/PendingConnectionsScreen.tsx
+++ b/BrightID/src/components/PendingConnections/PendingConnectionsScreen.tsx
@@ -2,13 +2,13 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useState,
   useRef,
+  useState,
 } from 'react';
 import {
   BackHandler,
-  StyleSheet,
   StatusBar,
+  StyleSheet,
   Text,
   TouchableOpacity,
   View,
@@ -21,13 +21,13 @@ import ViewPager from '@react-native-community/viewpager';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from '@/store/hooks';
 import { selectAllUnconfirmedConnections } from '@/components/PendingConnections/pendingConnectionSlice';
-import { DEVICE_LARGE, DEVICE_ANDROID } from '@/utils/deviceConstants';
-import { WHITE, GREY, DARK_GREY, BLACK, ORANGE } from '@/theme/colors';
+import { DEVICE_ANDROID, DEVICE_LARGE } from '@/utils/deviceConstants';
+import { BLACK, DARK_GREY, GREY, ORANGE, WHITE } from '@/theme/colors';
 import { fontSize } from '@/theme/fonts';
 import { setActiveNotification } from '@/actions';
 import { PreviewConnectionController } from './PreviewConnectionController';
 import BackArrow from '../Icons/BackArrow';
-import { backupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
+import { syncAndBackupUser } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 
 /**
  * Confirm / Preview Connection  Screen of BrightID
@@ -127,7 +127,7 @@ export const PendingConnectionsScreen = () => {
     if (pendingConnections.length === 0) {
       // Trigger backup of connections when when all pending connections are handled
       if (backupCompleted) {
-        dispatch(backupUser());
+        dispatch(syncAndBackupUser());
       }
       setLoading(true);
       timeout = setTimeout(() => {

--- a/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
+++ b/BrightID/src/components/PendingConnections/actions/pendingConnectionThunks.ts
@@ -1,10 +1,7 @@
 import { selectChannelById } from '@/components/PendingConnections/channelSlice';
 import { addConnection, addOperation } from '@/actions';
 import { saveImage } from '@/utils/filesystem';
-import {
-  backupPhoto,
-  backupUser,
-} from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
+import { backupPhoto } from '@/components/Onboarding/RecoveryFlow/thunks/backupThunks';
 import {
   confirmPendingConnection,
   pendingConnection_states,
@@ -12,8 +9,8 @@ import {
   updatePendingConnection,
 } from '@/components/PendingConnections/pendingConnectionSlice';
 import {
-  leaveChannel,
   encryptAndUploadProfileToChannel,
+  leaveChannel,
 } from '@/components/PendingConnections/actions/channelThunks';
 import { NodeApi } from '@/api/brightId';
 import { channel_types, connection_levels } from '@/utils/constants';

--- a/BrightID/src/reducer/connectionsSlice.ts
+++ b/BrightID/src/reducer/connectionsSlice.ts
@@ -1,7 +1,7 @@
 import {
+  createEntityAdapter,
   createSelector,
   createSlice,
-  createEntityAdapter,
   PayloadAction,
   Update,
 } from '@reduxjs/toolkit';


### PR DESCRIPTION
Currently if a user uses multiple devices to make connections, the device that is used later will override the backup data and does not load the current backup data related to the connections made by their other device. I created this PR to make sure that multiple devices stay in sync with the backup service while creating connections