### PR TITLE
Change the theme of react-native-image-crop-picker to dark for visibility of notifications 

### DIFF
--- a/BrightID/src/utils/images.ts
+++ b/BrightID/src/utils/images.ts
@@ -14,6 +14,11 @@ const options: Options = {
   useFrontCamera: true,
   compressImageQuality: 0.8,
   mediaType: 'photo',
+  cropperToolbarColor: '#1C2526', // Dark background for toolbar
+  cropperToolbarWidgetColor: '#FFFFFF', // White icons/text
+  cropperStatusBarColor: '#1C2526', // Dark status bar
+  cropperActiveWidgetColor: '#FFFFFF', // White for active elements
+  // cropperToolbarTextColor: '#FFFFFF', // White toolbar text
 };
 
 export const takePhoto = () =>


### PR DESCRIPTION
fixes https://github.com/BrightID/BrightID/issues/1244


<img width="1440" height="3040" alt="Screenshot_20250919_184529" src="https://github.com/user-attachments/assets/f171f9fe-5417-455e-809b-cbc278cadd92" />


I've changed the background of the `react-native-image-crop-picker` package by modifying the config. 